### PR TITLE
[WIP] Data Resource spec; new DRY way to write a spec

### DIFF
--- a/_data/specs/properties.json
+++ b/_data/specs/properties.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "define": {
+    "schema": {
+      "title": "Schema",
+      "description": "The JSON Table Schema that describes of this resource.",
+      "type": "object",
+          "properties": {
+            "fields": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "propertyOrder": 10
+                    },
+                    "title": {
+                      "type": "string",
+                      "propertyOrder": 20
+                    },
+                    "description": {
+                      "type": "string",
+                      "propertyOrder": 30
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "number",
+                        "integer",
+                        "boolean",
+                        "object",
+                        "array",
+                        "datetime",
+                        "date",
+                        "time",
+                        "duration",
+                        "geopoint",
+                        "geojson",
+                        "any"
+                      ],
+                      "propertyOrder": 40
+                    },
+                    "format": {
+                      "type": "string",
+                      "propertyOrder": 50
+                    }
+                  }
+              }
+            }
+          }
+    },
+    "name": {
+      "title": "Name",
+      "description": "An identifier for this package. Lower case characters with '.', '_' and '-' are allowed.",
+      "type": "string",
+      "pattern": "^([a-z0-9._-])+$"
+    },
+    "title": {
+      "title": "Title",
+      "description": "A human-readable title.",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "description": "A text description.",
+      "type": "string"
+    },
+    "homepage": {
+      "title": "Home Page",
+      "description": "The URL for this data package's website.",
+      "type": "string"
+    },
+    "version": {
+      "title": "Version",
+      "description": "A unique version number for this package.",
+      "type": "string"
+    },
+    "url": {
+      "title": "URL",
+      "description": "The URL for this resource.",
+      "type": "string"
+    },
+    "path": {
+      "title": "Path",
+      "description": "The relative path to this resource.",
+      "type": "string",
+      "example": "\"path\": \"file.csv\" \n\"path\": \"http://example.com/file.csv\""
+    },
+    "data": {
+      "title": "Data",
+      "description": "The inline data for this resource.",
+      "anyOf": [
+        { "type": "string" },
+        { "type": "array" },
+        { "type": "object" }
+      ]
+    },
+    "format": {
+      "title": "Format",
+      "description": "The file format of this resource.",
+      "type": "string"
+    },
+    "mediatype": {
+      "title": "Media Type",
+      "description": "The media type of this resource.",
+      "type": "string",
+      "pattern": "^(.+)/(.+)$"
+    },
+    "encoding": {
+      "title": "Encoding",
+      "description": "The file encoding of this resource.",
+      "type": "string"
+    },
+    "bytes": {
+      "title": "Bytes",
+      "description": "The size of this resource in bytes.",
+      "type": "integer"
+    },
+    "hash": {
+      "title": "Hash",
+      "type": "string",
+      "description": "The MD5 hash of this resource. Indicate other hashing algorithms with the {algorithm}:{hash} format.",
+      "pattern": "^([^:]+:[a-fA-F0-9]+|[a-fA-F0-9]{32}|)$"
+    },
+    "dialect": {
+      "title": "Dialect",
+      "description": "The dialect of this resource file type.",
+      "type": "object"
+    },
+    "author": {
+      "title": "Author",
+      "description": "A contributor to this package.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string" },
+            "web": { "type": "string" }
+          },
+          "required": [ "name" ]
+        }
+      ]
+    },
+    "contributors": {
+      "title": "Contributors",
+      "description": "The contributors to this package.",
+      "type": "array",
+      "items": {
+        "$ref": "#/define/author"
+      }
+    },
+    "licenses": {
+      "title": "License",
+      "description": "The license under which this package is published.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "url": { "type": "string" }
+          },
+          "anyOf": [
+            { "title": "type required", "required": [ "type" ] },
+            { "title": "url required", "required": [ "url" ] }
+          ]
+        }
+      ]
+    },
+    "sources": {
+      "title": "Sources",
+      "description": "The raw sources for this resource.",
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "web": { "type": "string" },
+          "email": { "type": "string" }
+        },
+        "anyOf": [
+          { "title": "name required", "required": ["name"] },
+          { "title": "web required", "required": ["web"] },
+          { "title": "email required", "required": ["email"] }
+        ]
+      }
+    },
+    "keywords": {
+      "title": "Keywords",
+      "description": "A list of keywords that describe this package.",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "image": {
+      "title": "Image",
+      "description": "A image to represent this package.",
+      "type": "string"
+    },
+    "dataDependencies": {
+      "title": "Data Dependencies",
+      "description": "Additional Data Packages required to install this package.",
+      "type": "object"
+    },
+    "countryCode": {
+      "title": "ISO 3166-1 Alpha-2 Country code",
+      "description": "A valid 2-digit ISO country code (ISO 3166-1 alpha-2), or, an array of valid ISO codes.",
+      "oneOf": [
+        { "type": "string", "pattern": "^[A-Z]{2}$" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^[A-Z]{2}$" }
+        }
+      ]
+    }
+  }
+}

--- a/_includes/abstract.md
+++ b/_includes/abstract.md
@@ -1,0 +1,3 @@
+# Abstract
+
+{{ page.abstract }}

--- a/_includes/descriptor.md
+++ b/_includes/descriptor.md
@@ -1,0 +1,12 @@
+## Descriptor
+
+A valid {{ page.title }} descriptor is an `object` adhering to the specifications of this document.
+
+The descriptor `MUST` be in one of the following forms:
+
+1. A file named `{{ page.descriptor.file }}`.
+2. An `object` nested in another data structure.
+
+Where a {{ page.title }} descriptor is a file with references to additional co-located resources on a file system, the `{{ page.descriptor.file }}` descriptor `MUST` be at the top-level directory, with those resources in a relative location to the descriptor file.
+
+All Frictionless Data descriptors `MUST` be serialised as JSON.

--- a/_includes/descriptor.md
+++ b/_includes/descriptor.md
@@ -10,3 +10,5 @@ The descriptor `MUST` be in one of the following forms:
 Where a {{ page.title }} descriptor is a file with references to additional co-located resources on a file system, the `{{ page.descriptor.file }}` descriptor `MUST` be at the top-level directory, with those resources in a relative location to the descriptor file.
 
 All Frictionless Data descriptors `MUST` be serialised as JSON.
+
+The media type for {{ page.title }} descriptors as files `MUST` be `{{ page.mediatype }}`.

--- a/_includes/examples.md
+++ b/_includes/examples.md
@@ -1,0 +1,5 @@
+## Examples
+
+{% for example in page.examples %}
+{% include {{ example }} %}
+{% endfor %}

--- a/_includes/examples/dataresource_1.md
+++ b/_includes/examples/dataresource_1.md
@@ -1,0 +1,15 @@
+A minimal {{ page.title }} looks as follows.
+
+```
+# with data accessible via the local filesystem
+{
+  "name": "resource-name",
+  "path": "resource-path.csv"
+}
+
+# with data accessible via http
+{
+  "name": "resource-name",
+  "path": "http://example.com/resource-path.csv"
+}
+```

--- a/_includes/examples/dataresource_2.md
+++ b/_includes/examples/dataresource_2.md
@@ -1,0 +1,11 @@
+A minimal {{ page.title }} example using the `data` property to inline data looks as follows.
+
+```
+{
+  "name": "resource-name",
+  "data": [
+    {"a": 1, "b": 2}
+  ]
+}
+```
+

--- a/_includes/examples/dataresource_3.md
+++ b/_includes/examples/dataresource_3.md
@@ -1,0 +1,19 @@
+A comprehensive {{ page.title }} example with all required, recommended and optional properties looks as follows.
+
+```
+{
+  "name": "solar-system",
+  "path": "http://example.com/solar-system.csv",
+  "title": "The Solar System",
+  "description": "My favourite data about the solar system.",
+  "format": "csv",
+  "mediatype": "text/csv",
+  "encoding": "utf-8",
+  "bytes": 1,
+  "hash": "",
+  "schema": "",
+  "sources": "",
+  "licenses": ""
+}
+```
+

--- a/_includes/language.md
+++ b/_includes/language.md
@@ -1,6 +1,3 @@
-Language
-========
+# Language
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
-
-[RFC 2119]: https://www.ietf.org/rfc/rfc2119.txt
+The key words **`MUST`**, **`MUST NOT`**, **`REQUIRED`**, **`SHALL`**, **`SHALL NOT`**, **`SHOULD`**, **`SHOULD NOT`**, **`RECOMMENDED`**, **`MAY`**, and **`OPTIONAL`** in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,15 +1,39 @@
+# Meta
+
 <table class="table table-striped meta">
-  {% if page.author %}
-    <tr><td>Author</td><td>{% for author in page.author %}{{author}}<br />{% endfor %}</td></tr>
+  {% if page %}
+  <tr>
+    <td>Authors</td>
+    <td>
+      {% for author in page.authors %}
+      {{ author.name }} ({{ author.organisation }})<br />
+      {% endfor %}
+    </td>
+  </tr>
   {% endif %}
   {% if page.version %}
-    <tr><td>Version</td><td>{{page.version}}</td></tr>
+  <tr>
+    <td>Version</td>
+    <td>
+      {{ page.version }}
+    </td>
+  </tr>
   {% endif %}
   {% if page.updated %}
-    <tr><td>Last Updated</td><td>{{page.updated}}</td></tr>
+  <tr>
+    <td>Last Updated</td>
+    <td>
+      {{ page.updated }}
+    </td>
+  </tr>
   {% endif %}
   {% if page.created %}
-    <tr><td>Created</td><td>{{page.created}}</td></tr>
+  <tr>
+    <td>Created</td>
+    <td>
+      {{ page.created }}
+    </td>
+  </tr>
   {% endif %}
 </table>
 

--- a/_includes/notes.md
+++ b/_includes/notes.md
@@ -1,0 +1,9 @@
+## Notes
+
+<div class="alert">
+  <ul>
+    {% for note in page.notes %}
+    <li>{{ note }}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/_includes/properties.md
+++ b/_includes/properties.md
@@ -1,0 +1,66 @@
+{% assign definitions = site.data.specs.properties.define %}
+{% assign spec = site.data.specs[slug] %}
+
+## Properties
+
+This section presents a complete description of required, recommended, and optional properties for a {{ page.title }} descriptor.
+
+{% if page.properties.required %}
+### Required properties
+
+**A {{ page.title }} descriptor `MUST` include the following properties.**
+
+{% for prop in page.properties.required %}
+- `{{ prop }}`: {{ definitions[prop].description }}
+  {% if  definitions[prop].example %}
+  ```
+  # Example
+  {{ definitions[prop].example }}
+  ```
+  {% endif %}
+  {% if  definitions[prop].context %}
+  {{ definitions[prop].context }}
+  {% endif %}
+{% endfor %}
+
+{% endif %}
+
+{% if page.properties.recommended %}
+### Recommended properties
+
+**A {{ page.title }} descriptor `SHOULD` include the following properties.**
+
+{% for prop in page.properties.recommended %}
+- `{{ prop }}`: {{ definitions[prop].description }}
+  {% if  definitions[prop].example %}
+  ```
+  # Example
+  {{ definitions[prop].example }}
+  ```
+  {% endif %}
+  {% if  definitions[prop].context %}
+  {{ definitions[prop].context }}
+  {% endif %}
+{% endfor %}
+
+{% endif %}
+
+{% if page.properties.optional %}
+### Optional properties
+
+**A {{ page.title }} descriptor `MAY` include the following properties.**
+
+{% for prop in page.properties.optional %}
+- `{{ prop }}`: {{ definitions[prop].description }}
+  {% if  definitions[prop].example %}
+  ```
+  # Example
+  {{ definitions[prop].example }}
+  ```
+  {% endif %}
+  {% if  definitions[prop].context %}
+  {{ definitions[prop].context }}
+  {% endif %}
+{% endfor %}
+
+{% endif %}

--- a/_includes/security.md
+++ b/_includes/security.md
@@ -1,0 +1,7 @@
+## Security
+
+### The `path` property
+
+`/` (absolute path) and `../` (relative parent path) are **forbidden** in all Frictionless Data specifications. This limitation is imposed to avoid security vulnerabilities when implementing data package tools by ensuring that resource paths only point to files within the data package directory and its subdirectories. This prevents data package tools being exploited by a malicious user to gain unintended access to sensitive information.
+
+For example, suppose a data package hosting service stores packages on disk and allows access via an API. A malicious user uploads a data package with a resource path like /etc/passwd. The user then requests the data for that resource and the server naively opens /etc/passwd and returns that data to the caller.

--- a/_layouts/basespec.html
+++ b/_layouts/basespec.html
@@ -1,0 +1,44 @@
+---
+layout: default
+---
+
+{% if page.redirect_to %}
+<p>Moved: <a href="{{ page.redirect_to }}">{{ page.redirect_to }}</a></p>
+<hr>
+{% else %}
+
+{% capture abstract %}{% include abstract.md %}{% endcapture %}
+{{ abstract | markdownify }}
+
+{% capture meta %}{% include meta.html %}{% endcapture %}
+{{ meta | markdownify }}
+
+{% capture language %}{% include language.md %}{% endcapture %}
+{{ language | markdownify }}
+
+<h1>Specification</h1>
+
+{% capture descriptor %}{% include descriptor.md %}{% endcapture %}
+{{ descriptor | markdownify }}
+
+{% if page.title %}
+{% capture target %}{{ "# " | append: page.title  | markdownify }}{% endcapture %}
+{{ content | replace: target, '' }}
+{% else %}
+{{ content }}
+{% endif %}
+
+{% capture examples %}{% include examples.md %}{% endcapture %}
+{{ examples | markdownify }}
+
+{% capture properties %}{% include properties.md %}{% endcapture %}
+{{ properties | markdownify }}
+
+{% capture notes %}{% include notes.md %}{% endcapture %}
+{{ notes | markdownify }}
+
+{% capture security %}{% include security.md %}{% endcapture %}
+{{ security | markdownify }}
+
+{% endif %}
+

--- a/dataresource/index.md
+++ b/dataresource/index.md
@@ -1,0 +1,56 @@
+---
+title: Data Resource
+slug: dataresource
+subtitle: A simple format to describe data and metadata.
+layout: basespec
+listed: true
+version: 1.0-alpha-1
+updated: 11 December 2017
+created: 11 December 2017
+authors:
+  -
+    name: Rufus Pollock
+    organisation: Open Knowledge International
+  -
+    name: Paul Walsh
+    organisation: Open Knowledge International
+descriptor:
+  file: dataresource.json
+properties:
+  required:
+    - name
+    - path
+    - data
+  recommended:
+  optional:
+    - title
+    - description
+    - format
+    - mediatype
+    - encoding
+    - bytes
+    - hash
+    - schema
+    - sources
+    - licenses
+examples:
+  - examples/dataresource_1.md
+  - examples/dataresource_2.md
+  - examples/dataresource_3.md
+notes:
+  - Prior to Nov 17 2016, there was a `url` property distinct from `path`. In order to support backwards compatability, implementors `MAY` want to automatically convert a `url` property to a `path` property and issue a warning.
+  - When `path` is an array, all data sources in the array `MUST` be of the same type (i.e.: all http URLs, or all file paths).
+  - When `path` is an all data sources in the array `MUST` be similar in terms of structure and format. Implementations `SHOULD` be able to simply concatenate the files together and treat the result as one large file.
+abstract: >
+  Data Resource is a simple container format used to describe and package a data source with additional metadata about that data source. By providing a minimum set of required properties and a range of recommended and optional properties, the format enables a simple contract for data interoperability that is governed by minimalism.
+---
+
+## Contents
+
+A **{{ page.title }}** is a simple container format that describes and packages a data source with additional information about that source.
+
+At a minimum, a {{ page.title }} requires a `name` property, and one of the `path` or `data` properties. `name` provides a human and machine-readable identifier for the {{ page.title }}. `data` provides the data source inlined directly into the descriptor. `path` is a URI or an array of URIs: to a file(s) on a file system, or over HTTP.
+
+A range of other properties can be declared to provide a richer set of metadata.
+
+Full information on **required**, **recommended**, and **optional** properties for a {{ page.title }} descriptor is provided in the [**Properties**](#properties) section below.

--- a/dataresource/index.md
+++ b/dataresource/index.md
@@ -5,6 +5,7 @@ subtitle: A simple format to describe data and metadata.
 layout: basespec
 listed: true
 version: 1.0-alpha-1
+mediatype: application/vnd.dataresource+json
 updated: 11 December 2017
 created: 11 December 2017
 authors:


### PR DESCRIPTION
**WIP: Do not merge.**

- Closes #327
- Closes #328

This PR implements the following:

- A first pass on a Data Resource (`dataresource.json`) specification
- A new way to generate a spec using the JSON Schema representation of the spec, and some common patterns to reduce inconsistent wording across specs, and standardise the structure of how specs are written for easier readability