### PR TITLE
Fixed pattern for name in common.yml

### DIFF
--- a/sources/dictionary/common.yml
+++ b/sources/dictionary/common.yml
@@ -21,7 +21,7 @@ name:
   title: Name
   description: An identifier string. Lower case characters with `.`, `_`, `-` and `/` are allowed.
   type: string
-  pattern: "^([a-z0-9._-/])+$"
+  pattern: "^([-a-z0-9._/])+$"
   context: This is ideally a url-usable and human-readable name. Name `SHOULD` be
     invariant, meaning it `SHOULD NOT` change when its parent descriptor is updated.
   examples:
@@ -91,9 +91,9 @@ homepage:
   examples:
   - |
       {
-        "homepage": { 
-          "name": "My Web Page", 
-          "uri": "http://example.com/" 
+        "homepage": {
+          "name": "My Web Page",
+          "uri": "http://example.com/"
         }
       }
 version:


### PR DESCRIPTION
Current spec was breaking python `jsonschema` library validation because of hyphen inside character class - http://stackoverflow.com/questions/28539253/python-regex-bad-character-range.

I'm putting hyphen to the safe place (as an option it could be escaped).