### PR TITLE
Replace accidental use of "<" in markdown

### DIFF
--- a/content/table-schema/contents.lr
+++ b/content/table-schema/contents.lr
@@ -242,11 +242,11 @@ A date without a time.
   library can attempt to parse the datetime via a range of strategies.
   An example is `dateutil.parser.parse` from the `python-dateutils`
   library.
-* **<PATTERN>**: date/time values in this field can be parsed according to
-  `<PATTERN>`. `<PATTERN>` MUST follow the syntax of [standard Python / C
+* **{PATTERN}**: date/time values in this field can be parsed according to
+  `{PATTERN}`. `{PATTERN}` MUST follow the syntax of [standard Python / C
   strptime][strptime]. (That is, values in the this field should be parseable
-  by Python / C standard `strptime` using `<PATTERN>`).  Example for
-  `<PATTERN>` is `%d %b %y` which would correspond to dates like: `30 Nov 14`
+  by Python / C standard `strptime` using `{PATTERN}`).  Example for
+  `{PATTERN}` is `%d %b %y` which would correspond to dates like: `30 Nov 14`
 
 ### time
 


### PR DESCRIPTION
The word `<PATTERN>` is interpreted as an HTML tag in markdown so it isn't rendered as you can see below:
![markdown_error_fd](https://user-images.githubusercontent.com/8862002/27094682-9e441f74-5073-11e7-83cb-14dee364f859.png)

I replaced `<PATTERN>` with `{PATTERN}` which was already used in the docs.

