### PR TITLE
trueValues and falseValues for boolean fields

### DIFF
--- a/content/table-schema/contents.lr
+++ b/content/table-schema/contents.lr
@@ -208,11 +208,10 @@ Integer values are indicated in the standard way for any valid integer.
 
 The field contains boolean (true/false) data.
 
-Boolean values can be indicated with the following strings (case-insensitive
-so, for example, "Y" and "y" are both acceptable):
+In the physical representations of data where boolean values are represented with strings, the values set in `trueValues` and `falseValues` are to be cast to their logical representation as booleans. `trueValues` and `falseValues` are arrays which can be customised to user need. The default values for these are:
 
-* **true**: 'yes', 'y', 'true', 't', '1'
-* **false**: 'no', 'n', 'false', 'f', '0'
+* **trueValues**: `[ 'yes', 'y', 'true', 't', '1' ]`
+* **falseValues**: `[ 'no', 'n', 'false', 'f', '0' ]`
 
 `format`: no options (other than the default).
 

--- a/content/table-schema/contents.lr
+++ b/content/table-schema/contents.lr
@@ -208,10 +208,12 @@ Integer values are indicated in the standard way for any valid integer.
 
 The field contains boolean (true/false) data.
 
-In the physical representations of data where boolean values are represented with strings, the values set in `trueValues` and `falseValues` are to be cast to their logical representation as booleans. `trueValues` and `falseValues` are arrays which can be customised to user need. The default values for these are:
+In the physical representations of data where boolean values are represented with strings, the values set in `trueValues` and `falseValues` are to be cast to their logical representation as booleans. `trueValues` and `falseValues` are arrays which can be customised to user need. The default values for these are in the additional properties section below.
 
-* **trueValues**: `[ 'yes', 'y', 'true', 't', '1' ]`
-* **falseValues**: `[ 'no', 'n', 'false', 'f', '0' ]`
+The boolean field can be customised with these additional properties:
+
+* **trueValues**: `[ "true", "True", "TRUE", "1" ]`
+* **falseValues**: `[ "false", "False", "FALSE", "0" ]`
 
 `format`: no options (other than the default).
 

--- a/sources/dictionary/tableschema.yml
+++ b/sources/dictionary/tableschema.yml
@@ -164,6 +164,18 @@ tableSchemaForeignKey:
             type: string
           minItems: 1
           uniqueItems: true
+tableSchemaTrueValues:
+  type: array
+  minItems: 1
+  items:
+    type: string
+  default: [ "true", "True", "TRUE", "1" ]
+tableSchemaFalseValues:
+  type: array
+  minItems: 1
+  items:
+    type: string
+  default: [ "false", "False", "FALSE", "0" ]
 tableSchemaMissingValues:
   type: array
   minItems: 1
@@ -268,10 +280,6 @@ tableSchemaFieldBoolean:
   type: object
   title: Boolean Field
   description: The field contains boolean (true/false) data.
-  context: |-
-    Boolean values can be indicated with the following strings (case-insensitive, so, for example, 'Y' and 'y' are both acceptable):
-    * **true**: 'yes', 'y', 'true', 't', '1'
-    * **false**: 'no', 'n', 'false', 'f', '0'
   required:
     - name
     - type
@@ -286,6 +294,10 @@ tableSchemaFieldBoolean:
       description: The type keyword, which `MUST` be a value of `boolean`.
       enum:
       - boolean
+    trueValues:
+      "$ref": "#/definitions/tableSchemaTrueValues"
+    falseValues:
+      "$ref": "#/definitions/tableSchemaFalseValues"
     constraints:
       title: Constraints
       description: The following constraints are supported for `boolean` fields.


### PR DESCRIPTION
- Closes #415

@akariv @roll @rufuspollock note that this is *not* a property at the same level as `missingValues`, which is what I indicated in #415 . Rather, these are two properties applicable to BooleanFields.