### PR TITLE
path should be plain string format, not uri

### DIFF
--- a/sources/dictionary/common.yml
+++ b/sources/dictionary/common.yml
@@ -113,7 +113,6 @@ path:
   title: Path
   description: A fully qualified URL, or a POSIX file path..
   type: string
-  format: uri
   examples:
   - |
       {


### PR DESCRIPTION
### reproduction steps
* try to validate a descriptor with path fields containing relative file name
* for example:
```
{"resources": [
    {"name": "my-resource", "data": ["data/my-resource.csv"]}
]}
```

#### expected
* should validate with most common json schema validators
* should conform to json schema spec

#### actual
* this fails validation using [Php JsonSchema](https://github.com/justinrainbow/json-schema)
* the reason is that path / data is defined in spec as string with format `uri`: [dictionary/common.yml#L112](https://github.com/frictionlessdata/specs/blob/master/sources/dictionary/common.yml#L112)
* in the [json schema spec](http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3.6) this is defined as:  ```A string instance is valid against this attribute if it is a valid URI, according to RFC3986```
* relative file paths don't strictly conform to RFC3986

### notes
a minimalistic example in php showing that it fails validation (using [JsonSchema](https://github.com/justinrainbow/json-schema))
```php
        $validator = new \JsonSchema\Validator();
        // we will validate this against a simple schema of an array of uri strings
        $descriptor = ["data/data.csv"];
        $validator->validate(
            $descriptor,
            // this is a simple schema with only an array of uri strings
            (object)['$ref' => 'file://' . realpath(dirname(__FILE__)).'/fixtures/uri-string-schema.json']
        );
        // validation fails
        $this->assertFalse($validator->isValid());
        $this->assertEquals([[
            'property' => '[0]',
            'pointer' => '/0',
            // it considers file names to be invalid uris
            'message' => 'Invalid URL format',
            'constraint' => 'format',
            'context' => 1,
            'format' => 'uri'
        ]], $validator->getErrors());
```

uri-string-schema.json:
```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Testing uri string property",
  "type": "array",
  "minItems": 1,
  "items": {
    "type": "string",
    "format": "uri"
  }
}
```
