### PR TITLE
Update profile specs

### DIFF
--- a/content/profiles/contents.lr
+++ b/content/profiles/contents.lr
@@ -16,7 +16,7 @@ body:
 
 Different kinds of data need different data and metadata formats. To support these different data and metadata formats we need to extend and specialise the generic Data Package. These specialized types of Data Package (or Data Resource) are termed **profiles**. For example, there is a [Tabular Data Package][tdp] profile that specializes Data Packages specifically for tabular data.
 
-Thus, every Package and Resource descriptor has a profile. The default profile, if none is declared, is `default`. The namespace for the profile is the type of descriptor, so, default for a Package descriptor is not the same as default for a Resource descriptor.
+Thus, every Package and Resource descriptor has a profile. The namespace for the profile is the type of descriptor, so the default profile, if none is declared, is `data-package` for a Package descriptor and `data-resource` for a Resource descriptor.
 
 In summmary, an extension of Data Package may be formalised as a profile. A profile is a Data Package which extends the default specification towards more specific needs.
 
@@ -24,7 +24,7 @@ In summmary, an extension of Data Package may be formalised as a profile. A prof
 
 In addition to the concept, we need an explict way for publishers to state the profile they are using and consumers to discover this.
 
-Thus, we have a `profile` property that declares the profile for the descriptor for this Package or Resource. For the default Data Package and Data Resource descriptor, this SHOULD be present with a value of default, but if not, the absence of a profile is equivalent to setting "profile": "default".
+Thus, we have a `profile` property that declares the profile for the descriptor for this Package or Resource. For the default Data Package and Data Resource descriptor, this SHOULD be present with a value of `data-package`/`data-resource`, but if not, the absence of a profile is equivalent to setting `"profile": "data-package"`/ `"profile": "data-resource"`.
 
 Custom profiles MUST have a profile property, where the value is a unique identifier for that profile. This unique identifier `MUST` be a string and can be in one of two forms. It can be an id from the official [Data Package Schema Registry][registry], or, a fully-qualified URL that points directly to a JSON Schema that can be used to validate the profile.
 
@@ -36,4 +36,3 @@ As part of the Frictionless Data Specifications project, we publish a number of 
 [registry]: https://specs.frictionlessdata.io/schemas/registry.json
 [tdp]: /tabular-data-package/
 [fdp]: /fiscal-data-package/
-

--- a/content/profiles/contents.lr
+++ b/content/profiles/contents.lr
@@ -33,6 +33,11 @@ As part of the Frictionless Data Specifications project, we publish a number of 
 * [Tabular Data Package][tdp]
 * [Fiscal Data Package][fdp]
 
+We also publish the following Data Resource profiles:
+
+* [Tabular Data Resource][tdr]
+
 [registry]: https://specs.frictionlessdata.io/schemas/registry.json
 [tdp]: /tabular-data-package/
 [fdp]: /fiscal-data-package/
+[tdr]: /tabular-data-resource/

--- a/sources/dictionary/common.yml
+++ b/sources/dictionary/common.yml
@@ -3,11 +3,8 @@ profile:
   title: Profile
   description: The profile of this descriptor.
   context: Every Package and Resource descriptor has a profile. The default profile,
-    if none is declared, is `default`. The namespace for the profile is the type
-    of descriptor, so, `default` for a Package descriptor is not the same as `default`
-    for a Resource descriptor.
+    if none is declared, is `data-package` for Package and `data-resource` for Resource.
   type: string
-  default: default
   examples:
   - |
       {

--- a/sources/dictionary/package.yml
+++ b/sources/dictionary/package.yml
@@ -9,6 +9,7 @@ dataPackage:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
+      default: data-package
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20
@@ -56,6 +57,7 @@ tabularDataPackage:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
+      default: tabular-data-package
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20

--- a/sources/dictionary/package.yml
+++ b/sources/dictionary/package.yml
@@ -57,7 +57,6 @@ tabularDataPackage:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
-      default: tabular-data-package
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20

--- a/sources/dictionary/resource.yml
+++ b/sources/dictionary/resource.yml
@@ -86,7 +86,6 @@ tabularDataResource:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
-      default: tabular-data-resource
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20

--- a/sources/dictionary/resource.yml
+++ b/sources/dictionary/resource.yml
@@ -14,6 +14,7 @@ dataResource:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
+      default: data-resource
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20
@@ -85,6 +86,7 @@ tabularDataResource:
     profile:
       "$ref": "#/definitions/profile"
       propertyOrder: 10
+      default: tabular-data-resource
     name:
       "$ref": "#/definitions/name"
       propertyOrder: 20

--- a/templates/partials/profiles.html
+++ b/templates/partials/profiles.html
@@ -6,7 +6,7 @@
   A profile is declared on the <code>profile</code> property. For the default {{ this.title }} descriptor, this <code>SHOULD</code> be present with a value of <code>default</code>, but if not, the absence of a <code>profile</code> is equivalent to setting <code>"profile": "default"</code>.
 </p>
 <p>
-  Custom profiles <code>MUST</code> have a <code>profile</code> property, where the value is a unique identifier for that profile. This unique identifier can be in one of two forms. It can be an <code>id</code> from the official <a href="http://schemas.frictionlessdata.io/registry.json">Data Package Schema Registry</a>, or, a URI that points directly to a JSON Schema that can be used to validate the profile.
+  Custom profiles <code>MUST</code> have a <code>profile</code> property, where the value is a unique identifier for that profile. This unique identifier can be in one of two forms. It can be an <code>id</code> from the official <a href="https://specs.frictionlessdata.io/schemas/registry.json">Data Package Schema Registry</a>, or, a URI that points directly to a JSON Schema that can be used to validate the profile.
 </p>
 <p>
 As part of the {{ bag('site', 'name') }} project, we publish a number of {{ this.title }} profiles. See those profiles below.


### PR DESCRIPTION
Small changes that make things a bit more clear:

- updated the registry link
- referred to the default profiles by their name in the registry
- mentioned the existence of Tabular Data Resource since, as far as I understood, people should be able to use it independently from Tabular Data Package