### PR TITLE
Allow path and object on Resource schema property

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -122,7 +122,14 @@
     "anySchema": {
       "title": "Schema",
       "description": "A schema for this resource.",
-      "type": "object"
+      "oneOf": [
+        {
+          "$ref": "#/definitions/path"
+        },
+        {
+          "type": "object"
+        }
+      ]
     },
     "countryCode": {
       "title": "ISO 3166-1 Alpha-2 Country code",

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -159,7 +159,9 @@ image:
 anySchema:
   title: Schema
   description: A schema for this resource.
-  type: object
+  oneOf:
+   - "$ref": "#/definitions/path"
+   - type: object
 countryCode:
   title: ISO 3166-1 Alpha-2 Country code
   description: A valid 2-digit ISO country code (ISO 3166-1 alpha-2), or, an array of valid ISO codes.


### PR DESCRIPTION
According to the written specs:

> The value for the schema property on a resource MUST be an object
> representing the schema OR a string that identifies the location of
> the schema.

But the current JSON schema does not allow URLs or paths in the `schema`
property:

```
jsonschema.exceptions.ValidationError:
'http://iatistandard.org/202/schema/downloads/iati-activities-schema.xsd'
is not of type 'object'
```

I'm not 100% of how the specs are rebuilt, but this PR includes:

* Changes in `schemas/dictionary/common.yml` to allow a path in the
  `schema`.
* After running `npm run build`, `schemas/dictionary.json` is updated.

Let me know if this is not the right approach for rebuilding the
schemas.