### PR TITLE
add csv dialect available at url or path

### DIFF
--- a/specs/data-package.md
+++ b/specs/data-package.md
@@ -245,7 +245,7 @@ A URL for the home on the web that is related to this data package.
 
 #### `version`
 
-a version string identifying the version of the package. It should conform to the [Semantic Versioning][semver] requirements.
+a version string identifying the version of the package. It should conform to the [Semantic Versioning][semver] requirements and follow the [Data Package Version](https://frictionlessdata.io/specs/patterns/#data-package-version) pattern.
 
 #### `sources`
 

--- a/specs/data-package.md
+++ b/specs/data-package.md
@@ -265,7 +265,7 @@ The raw sources for this data package. It MUST be an array of Source objects. Ea
 The people or organizations who contributed to this Data Package. It MUST be an array. Each entry is a Contributor and MUST be an `object`. A Contributor MUST have a `title` property and MAY contain `path`, `email`, `role` and `organization` properties. An example of the object structure
   is as follows:
 
-      contributors: [{
+      "contributors": [{
         "title": "Joe Bloggs",
         "email": "joe@bloggs.com",
         "path": "http://www.bloggs.com",

--- a/specs/data-resource.md
+++ b/specs/data-resource.md
@@ -263,7 +263,7 @@ A Data Resource MAY have a `schema` property to describe the schema of the resou
 
 The value for the `schema` property on a `resource` MUST be an `object` representing the schema OR a `string` that identifies the location of the schema.
 
-If a `string` it must be a [url-or-path as defined above](#url-or-path), that is a fully qualified http URL or a relative POSIX path. The file at the the location specified by this url-or-path string `MUST` be a JSON document containing the schema.
+If a `string` it must be a [url-or-path as defined above](#url-or-path), that is a fully qualified http URL or a relative POSIX path. The file at the location specified by this url-or-path string `MUST` be a JSON document containing the schema.
 
 !! NOTE: the Data Package specification places no restrictions on the form of the schema Object. This flexibility enables specific communities to define schemas appropriate for the data they manage. As an example, the [Tabular Data Package][tdp] specification requires the schema to conform to [Table Schema][ts].
 

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -265,6 +265,8 @@ The Data Package version format follows the [Semantic Versioning](http://semver.
 
 The version numbers, and the way they change, convey meaning how the data package has been modified from one version to the next.
 
+### Specification
+
 Given a Data Package version number MAJOR.MINOR.PATCH, increment the:
 
 MAJOR version when you make incompatible changes, e.g.
@@ -317,4 +319,3 @@ In this case you want to specify that A depends on B and C -- and that "installi
 ### Implementations
 
 None known.
-

--- a/specs/tabular-data-package.md
+++ b/specs/tabular-data-package.md
@@ -95,6 +95,7 @@ B,3,4.5
   "resources": [
     {
       "path": "data.csv",
+      "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
@@ -116,4 +117,3 @@ B,3,4.5
 }
 
 ```
-

--- a/specs/tabular-data-resource.md
+++ b/specs/tabular-data-resource.md
@@ -169,7 +169,7 @@ If the CSV differs from this or the RFC in any other way regarding dialect (e.g.
 
 The value for the `dialect` property on a `resource` MUST be an `object` representing the dialect OR a `string` that identifies the location of the dialect.
 
-If a `string` it must be a [url-or-path](https://frictionlessdata.io/specs/data-resource/#url-or-path), that is a fully qualified http URL or a relative POSIX path. The file at the the location specified by this url-or-path string `MUST` be a JSON document containing the dialect.
+If a `string` it must be a [url-or-path](https://frictionlessdata.io/specs/data-resource/#url-or-path), that is a fully qualified http URL or a relative POSIX path. The file at the location specified by this url-or-path string `MUST` be a JSON document containing the dialect.
 
 ### JSON Tabular Data
 

--- a/specs/tabular-data-resource.md
+++ b/specs/tabular-data-resource.md
@@ -49,7 +49,8 @@ A minimal Tabular Data Resource looks as follows.
   "profile": "tabular-data-resource",
   "name": "resource-name",
   "path": [ "http://example.com/resource-path.csv" ],
-  "schema": "http://example.com/tableschema.json"
+  "schema": "http://example.com/tableschema.json",
+  "dialect": "http://example.com/csvdialect.json"
 }
 ```
 
@@ -117,11 +118,19 @@ A comprehensive Tabular Data Resource example with all required, recommended and
     "primaryKey": "id"
   },
   "dialect": {
-    "delimiter": ",",
+    "delimiter": ";",
     "doubleQuote": true
   },
-  "sources": "",
-  "licenses": ""
+  "sources": [{
+    "title": "The Solar System - 2001",
+    "path": "http://example.com/solar-system-2001.json",
+    "email": ""
+  }],
+  "licenses": [{
+    "name": "CC-BY-4.0",
+    "title": "Creative Commons Attribution 4.0",
+    "path": "https://creativecommons.org/licenses/by/4.0/"
+  }]
 }
 ```
 
@@ -156,7 +165,11 @@ NB: the RFC requires 7-bit ASCII encoding.
 
 The line terminator character `MUST` be LF or CRLF (the RFC allows CRLF only).
 
-If the CSV differs from this or the RFC in any other way regarding dialect (e.g. line terminators, quote charactors, field delimiters), the Tabular Data Resource MUST contain a `dialect` property describing its dialect. The `dialect` property MUST follow the [CSV Dialect][cd] specification.
+If the CSV differs from this or the RFC in any other way regarding dialect (e.g. line terminators, quote characters, field delimiters), the Tabular Data Resource MUST contain a `dialect` property describing its dialect. The `dialect` property MUST follow the [CSV Dialect][cd] specification.
+
+The value for the `dialect` property on a `resource` MUST be an `object` representing the dialect OR a `string` that identifies the location of the dialect.
+
+If a `string` it must be a [url-or-path](https://frictionlessdata.io/specs/data-resource/#url-or-path), that is a fully qualified http URL or a relative POSIX path. The file at the the location specified by this url-or-path string `MUST` be a JSON document containing the dialect.
 
 ### JSON Tabular Data
 
@@ -183,4 +196,3 @@ JSON Tabular Data MUST be an `array` where each item in the array MUST be:
   { "A": 4, "B": 5, "C": 6 }
 ]
 ```
-


### PR DESCRIPTION
- Improved TDR examples
- have not changed `version` or `updated` document metadata

@roll I have not included the dereferencing notes as part of the specs. Feel free to add that in. So this only partially fixes issue 561