### PR TITLE
Set quoteChar to one-character string

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -456,7 +456,7 @@
       },
       "examples": [
         "{\n  \"dialect\": {\n    \"delimiter\": \";\"\n  }\n}\n",
-        "{\n  \"dialect\": {\n    \"delimiter\": \"\\t\",\n    \"quoteChar\": \"''\"\n  }\n}\n"
+        "{\n  \"dialect\": {\n    \"delimiter\": \"\\t\",\n    \"quoteChar\": \"'\"\n  }\n}\n"
       ]
     },
     "delimiter": {
@@ -503,8 +503,7 @@
       "type": "string",
       "default": "\"",
       "examples": [
-        "{\n  \"quoteChar\": \"\"\n}\n",
-        "{\n  \"quoteChar\": \"''\"\n}\n"
+        "{\n  \"quoteChar\": \"'\"\n}\n"
       ]
     },
     "escapeChar": {

--- a/schemas/dictionary/dialect.yml
+++ b/schemas/dictionary/dialect.yml
@@ -36,7 +36,7 @@ csvDialect:
       {
         "dialect": {
           "delimiter": "\t",
-          "quoteChar": "''"
+          "quoteChar": "'"
         }
       }
 delimiter:
@@ -96,11 +96,7 @@ quoteChar:
   examples:
   - |
       {
-        "quoteChar": ""
-      }
-  - |
-      {
-        "quoteChar": "''"
+        "quoteChar": "'"
       }
 escapeChar:
   title: Escape Character


### PR DESCRIPTION
According to the [JSON Schema](https://frictionlessdata.io/schemas/csv-dialect.json) for CSV Dialect,

```
    "quoteChar": {
      "title": "Quote Character",
      "description": "Specifies a one-character string to use as the quoting character.",
      "type": "string",
      "default": "\"",
      "examples": [
        "{\n  \"quoteChar\": \"\"\n}\n",
        "{\n  \"quoteChar\": \"''\"\n}\n"
      ]
    }
```
But neither the empty string `""` nor the double single-quote `"''"` is a one-character string(?). In this pull request, I propose to use the single single-quote `"'"` as the main example instead.