### PR TITLE
fix licenses example "path" not "uri"

### DIFF
--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -259,7 +259,8 @@ licenses:
         "licenses": [
           {
             "name": "odc-pddl-1.0",
-            "uri": "http://opendatacommons.org/licenses/pddl/"
+            "path": "http://opendatacommons.org/licenses/pddl/",
+            "title": "Open Data Commons Public Domain Dedication and License v1.0"
           }
         ]
       }


### PR DESCRIPTION
add "title" for a complete example

fixes #581