### PR TITLE
Added a pattern for 'path' property

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "glob": "^7.1.1",
     "js-yaml": "^3.7.0",
     "json-schema-ref-parser": "^3.1.2",
-    "mocha": "^4.0.1"
+    "mocha": "^4.0.1",
+    "tv4": "^1.3.0"
   }
 }

--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -78,7 +78,7 @@
       "title": "Path",
       "description": "A fully qualified URL, or a POSIX file path..",
       "type": "string",
-      "pattern": "^[^./~]",
+      "pattern": "^(?=^[^./~])(^((?!\\.{2}).)*$).*$",
       "examples": [
         "{\n  \"path\": \"file.csv\"\n}\n",
         "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"

--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -78,6 +78,7 @@
       "title": "Path",
       "description": "A fully qualified URL, or a POSIX file path..",
       "type": "string",
+      "pattern": "^[^./~]",
       "examples": [
         "{\n  \"path\": \"file.csv\"\n}\n",
         "{\n  \"path\": \"http://example.com/file.csv\"\n}\n"

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -101,7 +101,7 @@ path:
   title: Path
   description: A fully qualified URL, or a POSIX file path..
   type: string
-  pattern: "^[^./~]"
+  pattern: "^(?=^[^./~])(^((?!\\.{2}).)*$).*$"
   examples:
   - |
       {

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -101,6 +101,7 @@ path:
   title: Path
   description: A fully qualified URL, or a POSIX file path..
   type: string
+  pattern: "^[^./~]"
   examples:
   - |
       {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -57,7 +57,7 @@ describe('schemas', () => {
       assert.isFalse(validation.valid)
       assert.strictEqual(
         validation.errors[0].subErrors[0].message,
-        'String does not match pattern: ^[^./~]'
+        'String does not match pattern: ^(?=^[^./~])(^((?!\\.{2}).)*$).*$'
       )
     })
 

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -38,8 +38,16 @@ describe('schemas', () => {
   })
 
   it('data-resource path property', async () => {
+
+    // Valid paths
     const schema = require('../build/schemas/data-resource.json')
-    const invalidPaths = ['../dest', './dest', '/dest', '~/dest']
+    const invalidPaths = [
+      '../dest',
+      './dest',
+      '/dest',
+      '~/dest',
+      'dest/../../bad',
+    ]
     let validation
     invalidPaths.forEach(path => {
       validation = tv4.validateMultiple(
@@ -52,12 +60,21 @@ describe('schemas', () => {
         'String does not match pattern: ^[^./~]'
       )
     })
-    // Now let's test with valid path:
-    validation = tv4.validateMultiple(
-      {name: 'test', path: 'dest'},
-      schema
-    )
-    assert.isTrue(validation.valid)
+
+    // Invalid paths
+    const validPaths = [
+      'dest/some/file',
+      'dest/.some/file',
+      'dest',
+    ]
+    validPaths.forEach(path => {
+      validation = tv4.validateMultiple(
+        {name: 'test', path},
+        schema
+      )
+      assert.isTrue(validation.valid)
+    })
+
   })
 
   it('fiscal-data-package', async () => {

--- a/test/schemas.js
+++ b/test/schemas.js
@@ -2,6 +2,7 @@ const util = require('util')
 const {assert} = require('chai')
 const glob = util.promisify(require('glob'))
 const readFile = util.promisify(require('fs').readFile)
+const tv4 = require('tv4')
 
 
 // Tests
@@ -34,6 +35,29 @@ describe('schemas', () => {
   it('data-resource', async () => {
     const schema = require('../build/schemas/data-resource.json')
     assert.deepEqual(schema.title, 'Data Resource')
+  })
+
+  it('data-resource path property', async () => {
+    const schema = require('../build/schemas/data-resource.json')
+    const invalidPaths = ['../dest', './dest', '/dest', '~/dest']
+    let validation
+    invalidPaths.forEach(path => {
+      validation = tv4.validateMultiple(
+        {name: 'test', path},
+        schema
+      )
+      assert.isFalse(validation.valid)
+      assert.strictEqual(
+        validation.errors[0].subErrors[0].message,
+        'String does not match pattern: ^[^./~]'
+      )
+    })
+    // Now let's test with valid path:
+    validation = tv4.validateMultiple(
+      {name: 'test', path: 'dest'},
+      schema
+    )
+    assert.isTrue(validation.valid)
   })
 
   it('fiscal-data-package', async () => {


### PR DESCRIPTION
See the original issue here - https://github.com/frictionlessdata/tableschema-js/issues/133

As stated in https://frictionlessdata.io/specs/data-resource/#data-location, specs shouldn't accept a path that starts with `.` (which also includes `..`), `/` or `~`.

The security notice doesn't mention that `~` and `./` are forbidden.