### PR TITLE
Add overview and example to Foreign Keys to Data Packages pattern WIP

### DIFF
--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -253,9 +253,6 @@ http://example/com/data/lang/file2-es.csv
 
 ## Table Schema: Foreign Keys to Data Packages
 
-
-## Table Schema: Foreign Keys to Data Packages
-
 ### Overview
 
 A foreign key is a reference where values in a field (or fields) in a Tabular Data Resource link to values in a field (or fields) in a Tabular Data Resource in the same Tabular Data Package.

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -2,7 +2,7 @@ _model: page
 ---
 title: Patterns
 ---
-updated: 27 February 2018
+updated: 15 March 2018
 ---
 created: 11 December 2017
 ---
@@ -253,13 +253,32 @@ http://example/com/data/lang/file2-es.csv
 
 ## Table Schema: Foreign Keys to Data Packages
 
-Purpose: allow users to link from the column of a Tabular Data Resource in one Data Package to a Tabular Data Resource in another Data Package.
+### Overview
 
-To support this:
+A foreign key is a reference where values in a field (or fields) in a Tabular Data Resource link to values in a field (or fields) in a Tabular Data Resource in the same Tabular Data Package.
 
-The `foreignKey` MAY have a property `datapackage`. This property is a string being a url pointing to a Data Package or is the name of a datapackage.
+This pattern allows users to link values in a field (or fields) in a Tabular Data Resource to values in a field (or fields) in a Tabular Data Resource in a different Tabular Data Package.
+
+### Specification
+
+The `foreignKeys` array MAY have a property `datapackage`. This property is a string that is a fully qualified HTTP address to a Data Package `datapackage.json` file.
+
+For example:
+
+```
+"foreignKeys": [{
+    "fields": ["code"],
+    "reference": {
+      "datapackage": "https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/donation-codes/datapackage.json",
+      "resource": "donation-codes",
+      "fields": ["donation code"]
+    }
+  }],
+```
 
 ## Data Package Version
+
+### Specification
 
 The Data Package version format follows the [Semantic Versioning](http://semver.org) specification format: MAJOR.MINOR.PATCH
 

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -253,6 +253,9 @@ http://example/com/data/lang/file2-es.csv
 
 ## Table Schema: Foreign Keys to Data Packages
 
+
+## Table Schema: Foreign Keys to Data Packages
+
 ### Overview
 
 A foreign key is a reference where values in a field (or fields) in a Tabular Data Resource link to values in a field (or fields) in a Tabular Data Resource in the same Tabular Data Package.
@@ -261,7 +264,11 @@ This pattern allows users to link values in a field (or fields) in a Tabular Dat
 
 ### Specification
 
-The `foreignKeys` array MAY have a property `datapackage`. This property is a string that is a fully qualified HTTP address to a Data Package `datapackage.json` file.
+The [`foreignKeys`](https://frictionlessdata.io/specs/table-schema/#foreign-keys) array MAY have a property `datapackage`. This property MUST be, either:
+- a string that is a fully qualified HTTP address to a Data Package `datapackage.json` file
+- a data package [`name`](https://frictionlessdata.io/specs/data-package/#name) that can be resolved by a canonical data package registry 
+
+If the referenced data package has an [`id`](https://frictionlessdata.io/specs/data-package/#id) that is a fully qualified HTTP address, it SHOULD be used as the `datapackage` value.
 
 For example:
 
@@ -273,7 +280,7 @@ For example:
       "resource": "donation-codes",
       "fields": ["donation code"]
     }
-  }],
+  }]
 ```
 
 ## Data Package Version


### PR DESCRIPTION
Removes option to refer to data package `name` as no explanation offered in [forum](https://discuss.okfn.org/t/foreign-keys-across-data-packages/6460?u=stephen), [gitter](https://gitter.im/frictionlessdata/chat?at=5aa04d8d26a769820b2a769c) or [github](https://github.com/frictionlessdata/specs/issues/597).

Fixes #597