### PR TITLE
Add `commentChar` field to CSV dialect spec

### DIFF
--- a/schemas/dictionary/dialect.yml
+++ b/schemas/dictionary/dialect.yml
@@ -25,6 +25,8 @@ csvDialect:
       "$ref": "#/definitions/skipInitialSpace"
     header:
       "$ref": "#/definitions/header"
+    commentChar:
+      "$ref": "#/definitions/commentChar"
     caseSensitiveHeader:
       "$ref": "#/definitions/caseSensitiveHeader"
   examples:
@@ -38,7 +40,8 @@ csvDialect:
       {
         "dialect": {
           "delimiter": "\t",
-          "quoteChar": "'"
+          "quoteChar": "'",
+          "commentChar": "#"
         }
       }
 csvddfVersion:
@@ -51,7 +54,7 @@ csvddfVersion:
   - |
       {
         "csvddfVersion": "1.2"
-      }  
+      }
 delimiter:
   title: Delimiter
   description: A character sequence to use as the field separator.
@@ -142,6 +145,15 @@ header:
   - |
       {
         "header": true
+      }
+commentChar:
+  title: Comment Character
+  description: Specifies a character sequence causing the rest of the line after it to be ignored.
+  type: string
+  examples:
+  - |
+      {
+        "commentChar": "#"
       }
 caseSensitiveHeader:
   title: Case Sensitive Header

--- a/specs/csv-dialect.md
+++ b/specs/csv-dialect.md
@@ -49,6 +49,7 @@ A CSV Dialect descriptor, `dialect`, `MUST` be a JSON `object` with the followin
 * `nullSequence` - specifies the null sequence (for example `\N`). Not set by default
 * `skipInitialSpace` - specifies how to interpret whitespace which immediately follows a delimiter; if `false`, it means that whitespace immediately after a delimiter should be treated as part of the following field. Default = `true`
 * `header` - indicates whether the file includes a header row. If `true` the first row in the file is a header row, not data. Default = `true`
+* `commentChar` - indicates a one-character string to indicate lines whose remainder should be ignored
 * `caseSensitiveHeader` - indicates that case in the header is meaningful. For example, columns `CAT` and `Cat` should not be equated. Default = `false`
 * `csvddfVersion` - a number, in n.n format, e.g., `1.2`. If not present, consumers should assume latest schema version.
 
@@ -65,7 +66,8 @@ Here's an example:
     "lineTerminator": "\r\n",
     "quoteChar": "\"",
     "skipInitialSpace": true,
-    "header": true
+    "header": true,
+    "commentChar": "#"
   }
 }
 ```


### PR DESCRIPTION
As discussed in #254 I'd propose re-opening that discussion and probably include a comment char in the dialect spec. 