### PR TITLE
Add new properties to table-schema's schema

### DIFF
--- a/schemas/dictionary/tableschema.yml
+++ b/schemas/dictionary/tableschema.yml
@@ -73,6 +73,33 @@ tableSchema:
           }
     missingValues:
       "$ref": "#/definitions/tableSchemaMissingValues"
+    name:
+      "$ref": "#/definitions/name"
+    id:
+      "$ref": "#/definitions/id"
+    title:
+      "$ref": "#/definitions/title"
+    description:
+      "$ref": "#/definitions/description"
+      format: textarea
+    homepage:
+      "$ref": "#/definitions/homepage"
+    created:
+      "$ref": "#/definitions/created"
+    contributors:
+      "$ref": "#/definitions/contributors"
+    keywords:
+      "$ref": "#/definitions/keywords"
+    image:
+      "$ref": "#/definitions/image"
+    licenses:
+      "$ref": "#/definitions/licenses"
+    resources:
+      "$ref": "#/definitions/dataResources"
+    sources:
+      "$ref": "#/definitions/sources"
+      options:
+        hidden: true
   examples:
   - |
       {


### PR DESCRIPTION
Following #384 

Here is a proposition for adding new properties to the schema of table-schema.

This is a draft PR, I have many questions, see below.

I did not invent anything especially, but just reused existing definitions already used in the frictionlessdata family of specs (i.e. datapackage).

## Questions

- I removed `propertyOrder`, should I re-add them?
- I kept the `id` property, but is it relevant for schemas?
- Shouldn't there be an `updated` property, to go with `created`?
- Can we reuse `resources` for example CSV files? Even if the resource is invalid (in order to illustrate errors)?
- Can we reuse `source` to link to the document (i.e. a PDF file) that preceded the tableschema in JSON format?
- Why is `version` is documented on [the website](https://frictionlessdata.io/specs/data-package/) but not present in `package.yml`?
- What about rebuilding the file `schemas/dictionary.json` in the PR, should I do it before merge?

Thanks!