### PR TITLE
Add pattern for Table Schema metadata

### DIFF
--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -11,6 +11,7 @@ author:
  - Paul Walsh (Open Knowledge International)
  - Michael Amadi (Nimble Learn)
  - Christophe Benz (Jailbreak)
+ - Johan Richer (Jailbreak)
 ---
 summary: A collection of patterns for frictionless handling of data.
 ---
@@ -409,38 +410,111 @@ None known.
 
 ### Overview
 
-Adding metadata to describe schemas in a structured way would improve their understanding.
+ Table Schemas need their own metadata to be stand-alone and interpreted without relying on other contextual informations (Data Package metadata for example). Adding metadata to describe schemas in a structured way would help users to understand them and would increase their sharing and reuse.
 
-Table Schemas need their own metadata in order to be shared and interpreted as standalone, without relying on any Data Package metadata.
+Currently it is possible to add custom properties to a Table Schema, but the lack of consensus about those properties restricts common tooling and wider adoption.
 
-Potential use cases could be:
-- generate schemas documentation
-- schema cataloguing
+### Use cases
 
-Currently it is possible to add custom properties to a Table Schema, but the lack of consensus about those properties restricts tooling and wider adoption.
+- Documentation: generating Markdown documentation from the schema itself is a useful use case, and contextual information (description, version, authors...) needs to be retrieved.
+- Cataloging: open data standardisation can be increased by improving Table Schemas shareability, for example by searching and categorising them (by keywords, countries, full-text...) in catalogs.
+- Machine readibility: tools like Goodtables could use catalogs to access Table Schemas in order to help users validate tabular files against existing schemas. Metadata would be needed for tools to find and read those schemas.
 
 ### Specification
 
-This pattern proposes to introduce the following properties to the Table Schema spec:
+This pattern introduces the following properties to the Table Schema spec (using [the Frictionless Data core dictionary](https://github.com/frictionlessdata/specs/blob/master/schemas/dictionary/common.yml) as much as possible):
 
-- name
-- id
-- title
-- description
-- homepage
-- created
-- contributors
-- keywords
-- image
-- licenses
-- resources
-- sources
+- `name`: An identifier string for this schema.
+- `title`: A human-readable title for this schema.
+- `description`: A text description for this schema.
+- `keywords`: The keyword(s) that describe this schema.
+> Tags are useful to categorise and catalog schemas.
+- `countryCode`: The ISO 3166-1 alpha-2 code for the country where this schema is primarily used.
+> Since open data schemas are very country-specific, it's useful to have this information in a structure way.
+- `homepage`: The home on the web that is related to this schema.
+- `path`: A fully qualified URL for this schema.
+> The direct path to the schema itself can be useful to help acessing it (i.e. machine readibility).
+- `image`: An image to represent this schema.
+> An optional illustration can be useful for example in catalogs to differenciate schemas in a list.
+- `licenses`: The license(s) under which this schema is published.
+- `resources`: Example tabular data resource(s) validated or invalidated against this schema.
+> Oftentimes, schemas are shared with example resources to illustrate them, with valid or even invalid files (e.g. with constraint errors).
+- `sources`: The source(s) used to created this schema.
+> In some cases, schemas are created after a legal text or some draft specification in a human-readable document. In those cases, it's useful to share them with the schema.
+- `created`: The datetime on which this schema was created.
+- `lastModified`: The datetime on which this schema was last modified.
+- `version`: A unique version number for this schema.
+- `contributors`: The contributors to this schema.
 
-All those new properties are already specified (cf [common.yml](https://github.com/frictionlessdata/specs/blob/master/schemas/dictionary/common.yml)) and used by other Frictionless Data specs (e.g. Data Package).
+### Example schema
+
+```
+{
+  "$schema": "https://frictionlessdata.io/schemas/table-schema.json",
+  "name": "irve",
+  "title": "Infrastructures de recharge de véhicules électriques",
+  "description": "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",
+  "keywords": [
+      "electric vehicle",
+      "ev",
+      "charging station",
+      "mobility"
+  ],
+  "countryCode": "FR",
+  "homepage": "https://github.com/etalab/schema-irve",
+  "path": "https://github.com/etalab/schema-irve/raw/v1.0.1/schema.json",
+  "image": "https://github.com/etalab/schema-irve/raw/v1.0.1/irve.png",
+  "licenses": [
+    {
+      "title": "Creative Commons Zero v1.0 Universal",
+      "name": "CC0-1.0",
+      "path": "https://creativecommons.org/publicdomain/zero/1.0/"  
+    }
+  ],
+  "resources": [
+    {
+      "title": "Valid resource",
+      "name": "exemple-valide",
+      "path": "https://github.com/etalab/schema-irve/raw/v1.0.1/exemple-valide.csv"
+    },
+    {
+      "title": "Invalid resource",
+      "name": "exemple-invalide",
+      "path": "https://github.com/etalab/schema-irve/raw/v1.0.1/exemple-invalide.csv"      
+    }    
+  ],
+  "sources": [
+    {
+      "title": "Arrêté du 12 janvier 2017 relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques",      
+      "path": "https://www.legifrance.gouv.fr/eli/arrete/2017/1/12/ECFI1634257A/jo/texte"
+    }
+  ],
+  "created": "2018-06-29",
+  "lastModified": "2019-05-06",
+  "version": "1.0.1",  
+  "contributors": [
+    {
+      "title": "John Smith",
+      "email": "john.smith@etalab.gouv.fr",
+      "organisation": "Etalab",
+      "role": "author"
+    },
+    {
+      "title": "Jane Doe",
+      "email": "jane.doe@aol.com",
+      "organisation": "Civil Society Organization X",
+      "role": "contributor"
+    }
+  ],
+  "fields": [ ]
+}
+```
 
 ### Implementations
 
-The following links are actual use cases, not necessarily aligned with this pattern.
+The following links are actual examples already using this pattern, but not 100 % aligned with our proposal. The point is to make the Table Schema users converge towards a common pattern, before considering changing spec.
 
-- Schema from @Etalab using metadata properties: https://github.com/etalab/schema-irve/blob/master/schema.json
-- Example documentation generated from the schema: https://scdl.opendatafrance.net/docs/schemas/scdl-irve.html
+- @OpenDataFrance has initiated the creation of [Table Schemas](http://git.opendatafrance.net/scdl/) to standardise common French open data datasets. [Their Markdown documentation](http://scdl.opendatafrance.net/) is generated automatically from the schemas ([using some scripts](https://git.opendatafrance.net/validata/validata-doc-generator/)), including contextual information.
+- A tool called [Validata](https://go.validata.fr/) was developed, based on Goodtables, to help French open data producers follow the schemas. It uses metadata from the schemas to present them.
+- @Etalab has launched [schema.data.gouv.fr](http://schema.data.gouv.fr/), an official open data schema catalog, which is specific to France. [It needs additional metadata in the schemas to validate them](https://schema.data.gouv.fr/documentation/validation-schemas#validations-sp%C3%A9cifiques-au-format-table-schema).
+- [Example Table Schema](https://github.com/etalab/schema-irve/blob/master/schema.json) from @Etalab using metadata properties.

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -2,7 +2,7 @@ _model: page
 ---
 title: Patterns
 ---
-updated: 16 May 2019
+updated: 22 May 2019
 ---
 created: 11 December 2017
 ---
@@ -10,6 +10,7 @@ author:
  - Rufus Pollock (Open Knowledge International)
  - Paul Walsh (Open Knowledge International)
  - Michael Amadi (Nimble Learn)
+ - Christophe Benz (Jailbreak)
 ---
 summary: A collection of patterns for frictionless handling of data.
 ---
@@ -319,7 +320,7 @@ This pattern allows users to link values in a field (or fields) in a Tabular Dat
 
 The [`foreignKeys`](https://frictionlessdata.io/specs/table-schema/#foreign-keys) array MAY have a property `package`. This property MUST be, either:
 - a string that is a fully qualified HTTP address to a Data Package `datapackage.json` file
-- a data package [`name`](https://frictionlessdata.io/specs/data-package/#name) that can be resolved by a canonical data package registry 
+- a data package [`name`](https://frictionlessdata.io/specs/data-package/#name) that can be resolved by a canonical data package registry
 
 If the referenced data package has an [`id`](https://frictionlessdata.io/specs/data-package/#id) that is a fully qualified HTTP address, it SHOULD be used as the `package` value.
 
@@ -403,3 +404,43 @@ In this case you want to specify that A depends on B and C -- and that "installi
 ### Implementations
 
 None known.
+
+## Table Schema: metadata properties
+
+### Overview
+
+Adding metadata to describe schemas in a structured way would improve their understanding.
+
+Table Schemas need their own metadata in order to be shared and interpreted as standalone, without relying on any Data Package metadata.
+
+Potential use cases could be:
+- generate schemas documentation
+- schema cataloguing
+
+Currently it is possible to add custom properties to a Table Schema, but the lack of consensus about those properties restricts tooling and wider adoption.
+
+### Specification
+
+This pattern proposes to introduce the following properties to the Table Schema spec:
+
+- name
+- id
+- title
+- description
+- homepage
+- created
+- contributors
+- keywords
+- image
+- licenses
+- resources
+- sources
+
+All those new properties are already specified (cf [common.yml](https://github.com/frictionlessdata/specs/blob/master/schemas/dictionary/common.yml)) and used by other Frictionless Data specs (e.g. Data Package).
+
+### Implementations
+
+The following links are actual use cases, not necessarily aligned with this pattern.
+
+- Schema from @Etalab using metadata properties: https://github.com/etalab/schema-irve/blob/master/schema.json
+- Example documentation generated from the schema: https://scdl.opendatafrance.net/docs/schemas/scdl-irve.html

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -512,7 +512,7 @@ _In some cases, schemas are created after a legal text or some draft specificati
 
 ### Implementations
 
-The following links are actual examples already using this pattern, but not 100 % aligned with our proposal. The point is to make the Table Schema users converge towards a common pattern, before considering changing spec.
+The following links are actual examples already using this pattern, but not 100 % aligned with our proposal. The point is to make the Table Schema users converge towards a common pattern, before considering changing the spec.
 
 - @OpenDataFrance has initiated the creation of [Table Schemas](http://git.opendatafrance.net/scdl/) to standardise common French open data datasets. [Their Markdown documentation](http://scdl.opendatafrance.net/) is generated automatically from the schemas ([using some scripts](https://git.opendatafrance.net/validata/validata-doc-generator/)), including contextual information.
 - A tool called [Validata](https://go.validata.fr/) was developed, based on Goodtables, to help French open data producers follow the schemas. It uses metadata from the schemas to present them.

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -428,19 +428,19 @@ This pattern introduces the following properties to the Table Schema spec (using
 - `title`: A human-readable title for this schema.
 - `description`: A text description for this schema.
 - `keywords`: The keyword(s) that describe this schema.
-> Tags are useful to categorise and catalog schemas.
+_Tags are useful to categorise and catalog schemas._
 - `countryCode`: The ISO 3166-1 alpha-2 code for the country where this schema is primarily used.
-> Since open data schemas are very country-specific, it's useful to have this information in a structure way.
+_Since open data schemas are very country-specific, it's useful to have this information in a structured way._
 - `homepage`: The home on the web that is related to this schema.
 - `path`: A fully qualified URL for this schema.
-> The direct path to the schema itself can be useful to help acessing it (i.e. machine readibility).
+_The direct path to the schema itself can be useful to help acessing it (i.e. machine readibility)._
 - `image`: An image to represent this schema.
-> An optional illustration can be useful for example in catalogs to differenciate schemas in a list.
+_An optional illustration can be useful for example in catalogs to differenciate schemas in a list._
 - `licenses`: The license(s) under which this schema is published.
 - `resources`: Example tabular data resource(s) validated or invalidated against this schema.
-> Oftentimes, schemas are shared with example resources to illustrate them, with valid or even invalid files (e.g. with constraint errors).
+_Oftentimes, schemas are shared with example resources to illustrate them, with valid or even invalid files (e.g. with constraint errors)._
 - `sources`: The source(s) used to created this schema.
-> In some cases, schemas are created after a legal text or some draft specification in a human-readable document. In those cases, it's useful to share them with the schema.
+_In some cases, schemas are created after a legal text or some draft specification in a human-readable document. In those cases, it's useful to share them with the schema._
 - `created`: The datetime on which this schema was created.
 - `lastModified`: The datetime on which this schema was last modified.
 - `version`: A unique version number for this schema.


### PR DESCRIPTION
Follows #627 and #384 

This PR is marked as draft because before merging I'd like to discuss those questions with maintainers:

- I kept the `id` property, but is it relevant for schemas?
- Shouldn't there be an `updated` property, to go with `created`?
- Can we reuse `resources` for example CSV files? Even if the resource is invalid (in order to illustrate errors)?
- Can we reuse `source` to link to the document (i.e. a PDF file) that preceded the tableschema in JSON format?
- Why is `version` documented on [the website](https://frictionlessdata.io/specs/data-package/) but not present in `package.yml`?
