### PR TITLE
Document resources, Data package resources

### DIFF
--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -403,3 +403,148 @@ In this case you want to specify that A depends on B and C -- and that "installi
 ### Implementations
 
 None known.
+
+
+## Document Data Resources
+
+### Overview
+
+A simple format to describe a single structured document data resource such as a JSON document. It includes support both for metadata such as author and title and a [schema](https://json-schema.org/) to describe the data.
+
+### Introduction
+
+A **Document Data Resource** is a type of [Data Resource][dr] specialized for describing structured documents data like JSON documents.
+
+Document Data Resource extends [Data Resource][dr] in following key ways:
+
+* The `schema` property MUST follow the [JSON Schema](https://json-schema.org/) specification,
+  either as a JSON object directly under the property, or a string referencing another
+  JSON document containing the JSON Schema
+
+### Examples
+
+A minimal Document Data Resource, referencing external JSON documents, looks as follows.
+
+```javascript
+// with data and a schema accessible via the local filesystem
+{
+  "profile": "document-data-resource",
+  "name": "resource-name",
+  "path": [ "resource-path.json" ],
+  "schema": "jsonschema.json"
+}
+
+// with data accessible via http
+{
+  "profile": "document-data-resource",
+  "name": "resource-name",
+  "path": [ "http://example.com/resource-path.json" ],
+  "schema": "http://example.com/jsonschema.json"
+}
+```
+
+A minimal Document Data Resource example using the data property to inline data looks as follows.
+
+```javascript
+{
+  "profile": "document-data-resource",
+  "name": "resource-name",
+  "data": {
+    "id": 1,
+    "first_name": "Louise"
+  },
+  "schema": {
+    "type": "object",
+    "required": [
+      "id"
+    ],
+    "properties": {
+      "id": {
+        "type": "integer"
+      },
+      "first_name": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+A comprehensive JSON Data Resource example with all required, recommended and optional properties looks as follows.
+
+```javascript
+{
+  "profile": "document-data-resource",
+  "name": "solar-system",
+  "path": "http://example.com/solar-system.json",
+  "title": "The Solar System",
+  "description": "My favourite data about the solar system.",
+  "format": "json",
+  "mediatype": "application/json",
+  "encoding": "utf-8",
+  "bytes": 1,
+  "hash": "",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+      "id"
+    ],
+    "properties": {
+      "id": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "string"
+      }
+      "description": {
+        "type": "string"
+      }
+    }
+  },
+  "sources": [{
+    "title": "The Solar System - 2001",
+    "path": "http://example.com/solar-system-2001.json",
+    "email": ""
+  }],
+  "licenses": [{
+    "name": "CC-BY-4.0",
+    "title": "Creative Commons Attribution 4.0",
+    "path": "https://creativecommons.org/licenses/by/4.0/"
+  }]
+}
+```
+
+
+### Specification
+
+A Document Data Resource MUST be a [Data Resource][dr], that is it MUST conform to the [Data Resource specification][dr].
+
+In addition:
+
+* The Data Resource `schema` property MUST follow the [JSON Schema](https://json-schema.org/) specification,
+  either as a JSON object directly under the property, or a string referencing another
+  JSON document containing the JSON Schema
+- There `MUST` be a `profile` property with the value `document-data-resource`
+* The data the Data Resource describes MUST, if non-inline, be a JSON file
+
+
+### JSON file requirements
+
+When `"format": "json"`, files must strictly follow the [JSON specification](https://www.json.org/). Some implementations `MAY` support `"format": "jsonc"`, allowing for non-standard single line and block comments (`//` and `/* */` respectively).
+
+### Implementations
+
+None known.
+
+
+## Data Package Resources
+
+A [data resource][dr] where the `profile` is the same as that of a [data package][dp] or [identifier][dpi].
+
+This could be used as part of a "Data Package Catalog", probably specified as a `profile` like
+`data-package-catalog`,`tabular-data-package-catalog`, or `document-data-package-catalog` for restricting the resources to data packages.
+
+[dr]: http://frictionlessdata.io/specs/data-resource/
+[dp]: https://frictionlessdata.io/specs/data-package/
+[dpi]: https://frictionlessdata.io/specs/data-package-identifier/

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -542,9 +542,58 @@ None known.
 
 A [data resource][dr] where the `profile` is the same as that of a [data package][dp] or [identifier][dpi].
 
-This could be used as part of a "Data Package Catalog", probably specified as a `profile` like
-`data-package-catalog`,`tabular-data-package-catalog`, or `document-data-package-catalog` for restricting the resources to data packages.
+### Data Package Catalog
+Data Package Resources allow for Data Package Catalogs, specified as a `profile` such as `data-package-catalog` for restricting the resources to data packages, or `tabular-data-package-catalog` for restricting the resources to tabular data packages.
+
+#### Examples
+A generic package catalog:
+```json5
+{
+  "profile": "data-package-catalog",
+  "name": "climate-change-packages",
+  "resources": [
+    {
+      // this would probably actually be a custom profile,
+      // like "aq-deployment-data-package"
+      "profile": "json-data-package",
+      "name": "beacon-network-description",
+      "path": "https://http://beacon.berkeley.edu/hypothetical_deployment_description.json"
+    },
+    {
+      "profile": "tabular-data-package",
+      "path": "https://pkgstore.datahub.io/core/co2-ppm/10/datapackage.json"
+    },
+    {
+      "profile": "tabular-data-package",
+      "name": "co2-fossil-global",
+      "path": "https://pkgstore.datahub.io/core/co2-fossil-global/11/datapackage.json"
+    }
+  ]
+}
+```
+
+A tabular data catalog:
+```json5
+{
+  "profile": "tabular-data-package-catalog",
+  "name": "datahub-climate-change-packages",
+  "resources": [
+    {
+      "path": "https://pkgstore.datahub.io/core/co2-ppm/10/datapackage.json"
+    },
+    {
+      "name": "co2-fossil-global",
+      "path": "https://pkgstore.datahub.io/core/co2-fossil-global/11/datapackage.json"
+    }
+  ]
+}
+```
 
 [dr]: http://frictionlessdata.io/specs/data-resource/
 [dp]: https://frictionlessdata.io/specs/data-package/
 [dpi]: https://frictionlessdata.io/specs/data-package-identifier/
+
+### Implementations
+
+None known.
+

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -529,9 +529,9 @@ A simple format to describe a single structured document data resource such as a
 
 ### Introduction
 
-A **Document Data Resource** is a type of [Data Resource][dr] specialized for describing structured documents data like JSON documents.
+A **JSON Data Resource** is a type of [Data Resource][dr] specialized for describing structured JSON data.
 
-Document Data Resource extends [Data Resource][dr] in following key ways:
+JSON Data Resource extends [Data Resource][dr] in following key ways:
 
 * The `schema` property MUST follow the [JSON Schema](https://json-schema.org/) specification,
   either as a JSON object directly under the property, or a string referencing another
@@ -539,12 +539,12 @@ Document Data Resource extends [Data Resource][dr] in following key ways:
 
 ### Examples
 
-A minimal Document Data Resource, referencing external JSON documents, looks as follows.
+A minimal JSON Data Resource, referencing external JSON documents, looks as follows.
 
 ```javascript
 // with data and a schema accessible via the local filesystem
 {
-  "profile": "document-data-resource",
+  "profile": "json-data-resource",
   "name": "resource-name",
   "path": [ "resource-path.json" ],
   "schema": "jsonschema.json"
@@ -552,18 +552,18 @@ A minimal Document Data Resource, referencing external JSON documents, looks as 
 
 // with data accessible via http
 {
-  "profile": "document-data-resource",
+  "profile": "json-data-resource",
   "name": "resource-name",
   "path": [ "http://example.com/resource-path.json" ],
   "schema": "http://example.com/jsonschema.json"
 }
 ```
 
-A minimal Document Data Resource example using the data property to inline data looks as follows.
+A minimal JSON Data Resource example using the data property to inline data looks as follows.
 
 ```javascript
 {
-  "profile": "document-data-resource",
+  "profile": "json-data-resource",
   "name": "resource-name",
   "data": {
     "id": 1,
@@ -590,7 +590,7 @@ A comprehensive JSON Data Resource example with all required, recommended and op
 
 ```javascript
 {
-  "profile": "document-data-resource",
+  "profile": "json-data-resource",
   "name": "solar-system",
   "path": "http://example.com/solar-system.json",
   "title": "The Solar System",
@@ -634,14 +634,14 @@ A comprehensive JSON Data Resource example with all required, recommended and op
 
 ### Specification
 
-A Document Data Resource MUST be a [Data Resource][dr], that is it MUST conform to the [Data Resource specification][dr].
+A JSON Data Resource MUST be a [Data Resource][dr], that is it MUST conform to the [Data Resource specification][dr].
 
 In addition:
 
 * The Data Resource `schema` property MUST follow the [JSON Schema](https://json-schema.org/) specification,
   either as a JSON object directly under the property, or a string referencing another
   JSON document containing the JSON Schema
-- There `MUST` be a `profile` property with the value `document-data-resource`
+- There `MUST` be a `profile` property with the value `json-data-resource`
 * The data the Data Resource describes MUST, if non-inline, be a JSON file
 
 

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -658,11 +658,22 @@ None known.
 
 ### Overview
 
-In scenarios where one is dealing with a collection of data packages, such as when building an online registry, a data package catalog can be used.
+There are scenarios where one needs to describe a collection of data packages, such as when building an online registry, or when building a pipeline that ingests multiple datasets.
 
-A data package catalog is a data package where all the resources are [data packages][dp].
-It is specified by a `profile` property with the value `data-package-catalog`, or a `profile` that extends it, 
-such as a `tabular-data-package-catalog` for restricting the resources to tabular data packages.
+In these scenarios, the collection can be described using a "Catalog", where each dataset is represented as a single resource which has:
+```json
+{
+    "profile": "data-package",
+    "format": "json"
+}
+```
+
+### Specification
+Data Package Catalog builds directly on the Data Package specification. Thus a Data Package Catalog `MUST` be a Data Package and conform to the [Data Package specification][dp].
+
+The Data Package Catalog has the following requirements over and above those imposed by Data Package:
+* There `MUST` be a `profile` property with the value `data-package-catalog`, or a `profile` that extends it
+* Each resource `MUST` also be a Data Package
 
 #### Examples
 A generic package catalog:
@@ -672,26 +683,27 @@ A generic package catalog:
   "name": "climate-change-packages",
   "resources": [
     {
-      // this would probably actually be a custom profile,
-      // like "aq-deployment-data-package"
       "profile": "json-data-package",
+      "format": "json",
       "name": "beacon-network-description",
       "path": "https://http://beacon.berkeley.edu/hypothetical_deployment_description.json"
     },
     {
       "profile": "tabular-data-package",
+      "format": "json",
       "path": "https://pkgstore.datahub.io/core/co2-ppm/10/datapackage.json"
     },
     {
       "profile": "tabular-data-package",
       "name": "co2-fossil-global",
+      "format": "json",
       "path": "https://pkgstore.datahub.io/core/co2-fossil-global/11/datapackage.json"
     }
   ]
 }
 ```
 
-A tabular data catalog:
+A minimal tabular data catalog:
 ```json5
 {
   "profile": "tabular-data-package-catalog",

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -669,7 +669,7 @@ In these scenarios, the collection can be described using a "Catalog", where eac
 ```
 
 ### Specification
-Data Package Catalog builds directly on the Data Package specification. Thus a Data Package Catalog `MUST` be a Data Package and conform to the [Data Package specification][dp].
+The Data Package Catalog builds directly on the Data Package specification. Thus a Data Package Catalog `MUST` be a Data Package and conform to the [Data Package specification][dp].
 
 The Data Package Catalog has the following requirements over and above those imposed by Data Package:
 * There `MUST` be a `profile` property with the value `data-package-catalog`, or a `profile` that extends it

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -654,12 +654,15 @@ When `"format": "json"`, files must strictly follow the [JSON specification](htt
 None known.
 
 
-## Data Package Resources
+## Describing Data Package Catalogs using the Data Package Format
 
-A [data resource][dr] where the `profile` is the same as that of a [data package][dp] or [identifier][dpi].
+### Overview
 
-### Data Package Catalog
-Data Package Resources allow for Data Package Catalogs, specified as a `profile` such as `data-package-catalog` for restricting the resources to data packages, or `tabular-data-package-catalog` for restricting the resources to tabular data packages.
+In scenarios where one is dealing with a collection of data packages, such as when building an online registry, a data package catalog can be used.
+
+A data package catalog is a data package where all the resources are [data packages][dp].
+It is specified by a `profile` property with the value `data-package-catalog`, or a `profile` that extends it, 
+such as a `tabular-data-package-catalog` for restricting the resources to tabular data packages.
 
 #### Examples
 A generic package catalog:
@@ -707,7 +710,6 @@ A tabular data catalog:
 
 [dr]: http://frictionlessdata.io/specs/data-resource/
 [dp]: https://frictionlessdata.io/specs/data-package/
-[dpi]: https://frictionlessdata.io/specs/data-package-identifier/
 
 ### Implementations
 

--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -661,6 +661,7 @@ None known.
 There are scenarios where one needs to describe a collection of data packages, such as when building an online registry, or when building a pipeline that ingests multiple datasets.
 
 In these scenarios, the collection can be described using a "Catalog", where each dataset is represented as a single resource which has:
+
 ```json
 {
     "profile": "data-package",
@@ -669,6 +670,7 @@ In these scenarios, the collection can be described using a "Catalog", where eac
 ```
 
 ### Specification
+
 The Data Package Catalog builds directly on the Data Package specification. Thus a Data Package Catalog `MUST` be a Data Package and conform to the [Data Package specification][dp].
 
 The Data Package Catalog has the following requirements over and above those imposed by Data Package:
@@ -676,7 +678,9 @@ The Data Package Catalog has the following requirements over and above those imp
 * Each resource `MUST` also be a Data Package
 
 #### Examples
+
 A generic package catalog:
+
 ```json5
 {
   "profile": "data-package-catalog",
@@ -704,6 +708,7 @@ A generic package catalog:
 ```
 
 A minimal tabular data catalog:
+
 ```json5
 {
   "profile": "tabular-data-package-catalog",
@@ -715,6 +720,51 @@ A minimal tabular data catalog:
     {
       "name": "co2-fossil-global",
       "path": "https://pkgstore.datahub.io/core/co2-fossil-global/11/datapackage.json"
+    }
+  ]
+}
+```
+
+Data packages can also be declared inline in the data catalog:
+
+```json5
+{
+  "profile": "tabular-data-package-catalog",
+  "name": "my-data-catalog",
+  "resources": [
+    {
+      "profile": "tabular-data-package",
+      "name": "my-dataset",
+      // here we list the data files in this dataset
+      "resources": [
+        {
+          "profile": "tabular-data-resource",
+          "name": "resource-name",
+          "data": [
+            {
+              "id": 1,
+              "first_name": "Louise"
+            },
+            {
+              "id": 2,
+              "first_name": "Julia"
+            }
+          ],
+          "schema": {
+            "fields": [
+              {
+                "name": "id",
+                "type": "integer"
+              },
+              {
+                "name": "first_name",
+                "type": "string"
+              }
+            ],
+            "primaryKey": "id"
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
WIP for specs outlined in the data catalogue discussion: https://github.com/frictionlessdata/specs/issues/37#issuecomment-486745545

* adds a `document-data-resource` spec
* begins a `data-package-resource` spec
* minor edits to other docs to have more uniform style


I'm not entirely sure if `data-package-resource`s should be inherited from document resources, as while they _are_ structured documents, it creates a confusion of media types.