### PR TITLE
Define defaults for the required constraint

### DIFF
--- a/specs/table-schema.md
+++ b/specs/table-schema.md
@@ -6,7 +6,7 @@ mediatype: application/vnd.tableschema+json
 ---
 version: 1.0.0-rc.2
 ---
-updated: 24 March 2018
+updated: 10 September 2019
 ---
 created: 12 November 2012
 ---
@@ -410,7 +410,7 @@ properties.
       All
     </td>
     <td>
-      Indicates whether this field is allowed to be `null`. If required is `true`, then `null` is disallowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values.
+      Indicates whether this field cannot be `null`. If required is `false` (the default), then `null` is allowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values. Fields listed as [primary keys](#primary-keys) are required by default unless required is explicitly set to `false`.
     </td>
   </tr>
   <tr>
@@ -548,7 +548,8 @@ Examples:
 ### Primary Key
 
 A primary key is a field or set of fields that uniquely identifies each row in
-the table.
+the table. Such fields cannot be `null` unless explicitly permitted by adding
+`required: false` to their [`constraints` property](#constraints).
 
 The `primaryKey` entry in the schema `object` is optional. If present it specifies
 the primary key for this table.

--- a/specs/table-schema.md
+++ b/specs/table-schema.md
@@ -410,7 +410,7 @@ properties.
       All
     </td>
     <td>
-      Indicates whether this field cannot be `null`. If required is `false` (the default), then `null` is allowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values. Fields listed as [primary keys](#primary-keys) are required by default unless required is explicitly set to `false`.
+      Indicates whether this field cannot be `null`. If required is `false` (the default), then `null` is allowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values. Fields listed as [primary keys](#primary-key) are required by default unless required is explicitly set to `false`.
     </td>
   </tr>
   <tr>
@@ -549,7 +549,7 @@ Examples:
 
 A primary key is a field or set of fields that uniquely identifies each row in
 the table. Such fields cannot be `null` unless explicitly permitted by adding
-`required: false` to their [`constraints` property](#constraints).
+`required: false` to their [`constraints`](#constraints).
 
 The `primaryKey` entry in the schema `object` is optional. If present it specifies
 the primary key for this table.


### PR DESCRIPTION
- Fields are not required unless explicitly set to `true`
- Primary key fields are required unless explicitly set to `false`

per https://github.com/frictionlessdata/specs/issues/593 and https://github.com/frictionlessdata/goodtables-py/pull/252