### PR TITLE
Add pattern for defining row uniqueness constraints with Table Schema

### DIFF
--- a/specs/patterns.md
+++ b/specs/patterns.md
@@ -777,3 +777,64 @@ Data packages can also be declared inline in the data catalog:
 ### Implementations
 
 None known.
+
+## Table Schema: Unique constraint
+
+### Overview
+
+A `primaryKey` uniquely identifies each row in a table. Per SQL standards, it
+cannot contain `null` values. This pattern implements the SQL UNIQUE constraint
+by introducing a `uniqueKeys` array, defining one or more row uniqueness
+constraints which do support `null` values.
+
+### Specification
+
+The `uniqueKeys` property, if present, `MUST` be an array. Each entry in the
+array must be a `uniqueKey`. A `uniqueKey` `MUST` be an object and `MUST` have
+the following properties:
+
+- `fields` – A string or array (structured as per `primaryKey`) specifying the
+  resource field or fields required to be unique for each row in the table.
+- `nullUnique` – A boolean that dictates whether `null` are considered unique
+  (if `true`) or like any other value (if `false`).
+
+#### Examples
+
+| a | b | c | d |
+|---|---|---|---|
+| 1 | 1 | 1 | 1 |
+| 2 | 2 | `null` | 2 |
+| 3 | 2 | `null` | `null` |
+
+The above table meets the following primary key and two unique key constraints:
+
+```json
+{
+  "primaryKey": ["a"],
+  "uniqueKeys": [
+    {
+      "fields": ["b", "c"],
+      "nullUnique": true
+    },
+    {
+      "fields": ["c", "d"],
+      "nullUnique": false
+    }
+  ]
+}
+```
+
+The primary key `(a)` only contains unique, non-`null` values. In contrast, the
+unique keys can contain `null` values. Although unique key `(b, c)` contains two
+identical keys `(2, null)`, this is permitted because `nullUnique: true`
+specifies that `null` values are unique. This behavior is consistent with the
+UNIQUE constraint of PostgreSQL and most other SQL implementations, as
+illustrated by this
+[dbfiddle](https://dbfiddle.uk/?rdbms=postgres_11&fiddle=34cab8ba7d74b488d215a96f7e83c096).
+The same keys would be considered duplicates if `nullUnique: false`, consistent
+with the UNIQUE constraint of Microsoft SQL Server, as illustrated by this
+[dbfiddle](https://dbfiddle.uk/?rdbms=sqlserver_2019l&fiddle=34cab8ba7d74b488d215a96f7e83c096).
+
+### Implementations
+
+None known.

--- a/specs/table-schema.md
+++ b/specs/table-schema.md
@@ -548,7 +548,9 @@ Examples:
 ### Primary Key
 
 A primary key is a field or set of fields that uniquely identifies each row in
-the table.
+the table. Per SQL standards, the fields cannot be `null`, so their use in the
+primary key is equivalent to adding `required: true` to their
+[`constraints`](#constraints).
 
 The `primaryKey` entry in the schema `object` is optional. If present it specifies
 the primary key for this table.

--- a/specs/table-schema.md
+++ b/specs/table-schema.md
@@ -6,7 +6,7 @@ mediatype: application/vnd.tableschema+json
 ---
 version: 1.0.0-rc.2
 ---
-updated: 24 March 2018
+updated: 4 October 2019
 ---
 created: 12 November 2012
 ---
@@ -410,7 +410,7 @@ properties.
       All
     </td>
     <td>
-      Indicates whether this field is allowed to be `null`. If required is `true`, then `null` is disallowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values.
+      Indicates whether this field cannot be `null`. If required is `false` (the default), then `null` is allowed. See the section on `missingValues` for how, in the physical representation of the data, strings can represent `null` values.
     </td>
   </tr>
   <tr>
@@ -529,8 +529,8 @@ In additional to field descriptors, there are the following "table level" proper
 Many datasets arrive with missing data values, either because a value was not collected or it never existed. Missing values may be indicated simply by the value being empty in other cases a special value may have been used e.g. `-`, `NaN`, `0`, `-9999` etc.
 
 `missingValues` dictates which string values should be treated as `null` values. This conversion to `null` is done before any other attempted type-specific string conversion.
-The default value `[ "" ]` means that empty strings will be converted to null before any other processing takes place. 
-Providing the empty list `[]` means that no conversion to null will be done, on any value. 
+The default value `[ "" ]` means that empty strings will be converted to null before any other processing takes place.
+Providing the empty list `[]` means that no conversion to null will be done, on any value.
 
 
 `missingValues` MUST be an `array` where each entry is a `string`.


### PR DESCRIPTION
- Clarify that fields are not required unless explicitly set to `true`.
- Specify that `primaryKey` fields are required.
- Add a pattern for `uniqueKeys` which implements the SQL UNIQUE constraint.

per https://github.com/frictionlessdata/specs/issues/593 and https://github.com/frictionlessdata/goodtables-py/pull/252. Replaces my previous pull request https://github.com/frictionlessdata/specs/pull/642.



