### PR TITLE
Restricting `commentChar` to ignore a line only if it appears at the start

### DIFF
--- a/schemas/dictionary/dialect.yml
+++ b/schemas/dictionary/dialect.yml
@@ -148,7 +148,7 @@ header:
       }
 commentChar:
   title: Comment Character
-  description: Specifies a character sequence causing the rest of the line after it to be ignored.
+  description: Specifies that any line beginning with this character sequence, without preceeding whitespace, causes the entire line to be ignored.
   type: string
   examples:
   - |

--- a/schemas/dictionary/dialect.yml
+++ b/schemas/dictionary/dialect.yml
@@ -148,7 +148,7 @@ header:
       }
 commentChar:
   title: Comment Character
-  description: Specifies that any line beginning with this character sequence, without preceeding whitespace, causes the entire line to be ignored.
+  description: Specifies that any row beginning with this one-character string, without preceeding whitespace, causes the entire line to be ignored.
   type: string
   examples:
   - |

--- a/specs/csv-dialect.md
+++ b/specs/csv-dialect.md
@@ -49,7 +49,7 @@ A CSV Dialect descriptor, `dialect`, `MUST` be a JSON `object` with the followin
 * `nullSequence` - specifies the null sequence (for example `\N`). Not set by default
 * `skipInitialSpace` - specifies how to interpret whitespace which immediately follows a delimiter; if `false`, it means that whitespace immediately after a delimiter should be treated as part of the following field. Default = `true`
 * `header` - indicates whether the file includes a header row. If `true` the first row in the file is a header row, not data. Default = `true`
-* `commentChar` - indicates a one-character string to ignore any line that begins with this character
+* `commentChar` - indicates a one-character string to ignore any line whose row begins with this character
 * `caseSensitiveHeader` - indicates that case in the header is meaningful. For example, columns `CAT` and `Cat` should not be equated. Default = `false`
 * `csvddfVersion` - a number, in n.n format, e.g., `1.2`. If not present, consumers should assume latest schema version.
 

--- a/specs/csv-dialect.md
+++ b/specs/csv-dialect.md
@@ -49,7 +49,7 @@ A CSV Dialect descriptor, `dialect`, `MUST` be a JSON `object` with the followin
 * `nullSequence` - specifies the null sequence (for example `\N`). Not set by default
 * `skipInitialSpace` - specifies how to interpret whitespace which immediately follows a delimiter; if `false`, it means that whitespace immediately after a delimiter should be treated as part of the following field. Default = `true`
 * `header` - indicates whether the file includes a header row. If `true` the first row in the file is a header row, not data. Default = `true`
-* `commentChar` - indicates a one-character string to indicate lines whose remainder should be ignored
+* `commentChar` - indicates a one-character string to ignore any line that begins with this character
 * `caseSensitiveHeader` - indicates that case in the header is meaningful. For example, columns `CAT` and `Cat` should not be equated. Default = `false`
 * `csvddfVersion` - a number, in n.n format, e.g., `1.2`. If not present, consumers should assume latest schema version.
 


### PR DESCRIPTION
Per our discussion in issue #254, I've built upon #624 to simplify the behavior we're expecting. Otherwise, there are different interpretations of the behavior a `commentChar` could have and there is varied support is across different CSV parsers. The approach here sets a baseline for what a comment should do at minimum which we can later extend with additional attributes if need be.

Is it worth bumping up the version number? In theory this breaks compatibility with the previous description of `commentChar` even though this updated definition is in line with the original motivation of adding this feature.