### PR TITLE
Data Resource JSON schema definition for `dialect` seems to contradict specification

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -421,7 +421,17 @@
     "csvDialect": {
       "title": "CSV Dialect",
       "description": "The CSV dialect descriptor.",
-      "type": "object",
+      "oneOf": [
+        {
+          "title": "Dialect file path",
+          "description": "A fully qualified URL, or a POSIX file path.",
+          "type": "string"
+        },
+        {
+          "title": "Dialect as JSON",
+          "description": "A dialect encoded as a JSON object",
+          "type": "object"
+        }],
       "required": [
         "delimiter",
         "doubleQuote"


### PR DESCRIPTION
This is closely related to https://github.com/frictionlessdata/specs/issues/645 and describes basically the same bug, just for the way

According to human-readable spec (https://specs.frictionlessdata.io/tabular-data-resource/#csv-dialect), Dialect should bei either a JSON object or a file reference.

    The value for the dialect property on a resource MUST be an object representing the dialect OR a string that identifies the location of the dialect.

     If a string it must be a url-or-path, that is a fully qualified http URL or a relative POSIX path. The file at the the location specified by this url-or-path string MUST be a JSON document containing the dialect.

The corresponding definition, however, disallows paths or URLs and only allows JSON objects:

     "csvDialect": {
        "title": "CSV Dialect",
        "description": "The CSV dialect descriptor.",
        "type": "object",