### PR TITLE
Fix broken links

### DIFF
--- a/data-package/README.md
+++ b/data-package/README.md
@@ -105,7 +105,7 @@ Adherence to the specification does not imply that additional, non-specified pro
 
 This flexibility enables specific communities to extend Data Packages as appropriate for the data they manage. As an example, the [Tabular Data Package][tdp] specification extends Data Package to the case where all the data is tabular and stored in CSV.
 
-[tdp]: /specs/tabular-data-package/
+[tdp]: /tabular-data-package/
 
 Here is an illustrative example of a datapackage JSON file:
 
@@ -194,13 +194,13 @@ Here is an example:
 [od-licenses]: http://licenses.opendefinition.org/
 [od-approved]: http://opendefinition.org/licenses/
 [semver]: http://semver.org
-[url-or-path]: /specs/data-resource/#url-or-path
+[url-or-path]: /data-resource/#url-or-path
 
 ##### `profile`
 
 A string identifying the [profile][] of this descriptor as per the [profiles][profile] specification.
 
-[profile]: /specs/profiles/
+[profile]: /profiles/
 
 Examples:
 

--- a/data-resource/README.md
+++ b/data-resource/README.md
@@ -259,7 +259,7 @@ If a `string` it must be a [url-or-path as defined above](#url-or-path), that is
 NOTE: the Data Package specification places no restrictions on the form of the schema Object. This flexibility enables specific communities to define schemas appropriate for the data they manage. As an example, the [Tabular Data Package][tdp] specification requires the schema to conform to [Table Schema][ts].
 
 
-[tdp]: /specs/tabular-data-package/
-[ts]: /specs/table-schema/
+[tdp]: /tabular-data-package/
+[ts]: /table-schema/
 [iana]: http://www.iana.org/assignments/character-sets/character-sets.xhtml
-[dp]: /specs/data-package/
+[dp]: /data-package/

--- a/fiscal-data-package--budgets/README.md
+++ b/fiscal-data-package--budgets/README.md
@@ -47,7 +47,7 @@ The _ColumnTypes_ contained in this taxonomy contain:
 
 
 ## References
-- [The Fiscal Data Package Spec](/specs/fiscal-data-package/)
+- [The Fiscal Data Package Spec](/fiscal-data-package/)
 
 ## Location
 

--- a/fiscal-data-package--spending/README.md
+++ b/fiscal-data-package--spending/README.md
@@ -40,7 +40,7 @@ The _ColumnTypes_ contained in this taxonomy contain:
 - Some Geographic related types (esp. for addresses)
 
 ## References
-- [The Fiscal Data Package Spec](/specs/fiscal-data-package/)
+- [The Fiscal Data Package Spec](/fiscal-data-package/)
 
 ## Location 
 

--- a/fiscal-data-package/README.md
+++ b/fiscal-data-package/README.md
@@ -61,8 +61,8 @@ It concerns with how fiscal data should be packaged and providing means for publ
 On the other hand, this specification is, _by design_, non-opinionated about which data _should_ be published by publishers - which data-sets, which fields and and the internal processes these reflect.
 
 Alongside this specification are two fiscal taxonomies which serve as standards for publishing _budget_ files and _spending_ files. These can be found here:
-- [The Budget Fiscal Data Package Standard](/specs/fiscal-data-package--budgets/)
-- [The Spending Fiscal Data Package Standard](/specs/fiscal-data-package--spending/)
+- [The Budget Fiscal Data Package Standard](/fiscal-data-package--budgets/)
+- [The Spending Fiscal Data Package Standard](/fiscal-data-package--spending/)
 
 ### Lessons learned from v0.3 of this spec
 


### PR DESCRIPTION
## Intro

:wave: I've never contributed to this project before &ndash; I just saw some broken links on the website and thought the easiest/most helpful thing to do would be to just raise a PR. Apologies in advance if there are any guidelines/conventions I'm unaware of and should have adhered to.

## What

Change internal links (i.e. to other specifications) that are pointing to `/specs/...` to point to `/...`.

## Why

These links are currently broken on the <http://specs.frictionlessdata.io/> site.

**Example:** Visit <http://specs.frictionlessdata.io/data-package/#descriptor>, and click the "Tabular Data Package" link below the first code example in this section. You will see a 404. Removing `specs/` from the URL takes you to the right page.

**Caveat:** I haven't tested these changes locally, but I have checked each of the URLs that I've changed to confirm that they have the same problem on the live site (i.e. that `/specs/...` is a 404 but `/...` exists).