### PR TITLE
Correct compression examples

### DIFF
--- a/patterns/README.md
+++ b/patterns/README.md
@@ -154,6 +154,8 @@ Example of a compressed resource with implied compression:
   "path": "http://example.com/large-data-file.csv.gz",
   "title": "Large Data File",
   "description": "This large data file benefits from compression.",
+  "format": "csv",
+  "mediatype": "text/csv",
   "encoding": "utf-8",
   "bytes": 1073741824
 }
@@ -167,6 +169,10 @@ Example of a compressed resource with the `compression` property:
   "path": "http://example.com/large-data-file.csv.gz",
   "title": "Large Data File",
   "description": "This large data file benefits from compression.",
+  "format": "csv",
+  "compression" : "gz",
+  "mediatype": "text/csv",
+  "encoding": "utf-8",
   "bytes": 1073741824
 }
 ````


### PR DESCRIPTION
At https://specs.frictionlessdata.io/patterns/#specification-3 there is an example stating:

> Example of a compressed resource with the compression property:

But the actual example does not have the `compression` property. In fact, it just removes the `encoding` property compared with the example above. This is clearly incorrect.

I can't find out with "blame" what happened to the example or why, so I have corrected it to what was originally proposed in https://github.com/frictionlessdata/specs/pull/629/ when compression was introduced. That original proposal is also a bit more verbose: it includes `format` and `mediatype`.