### PR TITLE
Do not require order of fields to be the same in schema as csv

### DIFF
--- a/table-schema/README.md
+++ b/table-schema/README.md
@@ -3,7 +3,7 @@ title: Table Schema
 version: 1.0
 author: Paul Walsh, Rufus Pollock
 created: 12 November 2012
-updated: 4 October 2019
+updated: 6 October 2020
 descriptor: table-schema.json
 mediatype: application/vnd.tableschema+json
 abstract: A simple format to declare a schema for tabular data. The schema is designed to be expressible in JSON.
@@ -68,7 +68,7 @@ For example, `constraints` should be tested on the logical representation of dat
 
 A Table Schema is represented by a descriptor. The descriptor `MUST` be a JSON `object` (JSON is defined in [RFC 4627](http://www.ietf.org/rfc/rfc4627.txt)).
 
-It `MUST` contain a property `fields`. `fields` `MUST` be an array where each entry in the array is a field descriptor (as defined below). The order of elements in `fields` array `MUST` be the order of fields in the CSV file. The number of elements in `fields` array `SHOULD` be exactly the same as the number of fields in the CSV file.
+It `MUST` contain a property `fields`. `fields` `MUST` be an array where each entry in the array is a field descriptor (as defined below). The order of elements in `fields` array `SHOULD` be the order of fields in the CSV file. The number of elements in `fields` array `SHOULD` be the same as the number of fields in the CSV file.
 
 The descriptor `MAY` have the additional properties set out below and `MAY` contain any number of other properties (not defined in this specification).
 


### PR DESCRIPTION
See #704: strongly recommend, but do not require **order of fields** to be the same in schema as csv (`MUST` -> `SHOULD`). The **number of fields** was already strongly recommended, but not required. This change allows one to use external (community adopted) schemas with fewer or more fields in a different order. It is also already implemented as such in frictionless-py (`sync-schema` option).

I also removed the word "exactly" in:

> The number of elements in `fields` array `SHOULD` be ~exactly~ the same as the number of fields in the CSV file.

... as it seems a bit odd to use in combination with "should" and it is not used for "order" either.