### PR TITLE
Rebase da1660d: 'missing value per field pattern'

### DIFF
--- a/patterns/README.md
+++ b/patterns/README.md
@@ -965,3 +965,62 @@ re-packaged using these formats.
 To keep the implementation and testing testing: only one recursive level is
 possible. A `resource` can list `resources` inside (like in the example). But
 the inner resources cannot contain resources again.
+
+## Missing values per field
+
+### Overview
+
+Characters representing missing values in a table can be defined for all fields in a [Tabular Data Resource](http://frictionlessdata.io/specs/tabular-data-resource/) using the [`missingValues`](http://frictionlessdata.io/specs/table-schema/#missing-values) property in a Table Schema. Values that match the `missingValues` are treated as `null`.
+
+The Missing values per field pattern allows different missing values to be specified for each field in a Table Schema. If not specified, each field inherits from values assigned to `missingValues` at the Tabular Data Resource level.
+
+For example, this data...
+
+item | description | price
+---- | ----------- | -----
+1    | Apple       | 0.99
+tba  | Banana      | -1
+3    | n/a         | 1.20
+
+...using this Table Schema...
+
+```javascript
+"schema":{
+  "fields": [
+    {
+      "name": "item",
+      "title": "An inventory item number",
+      "type": "integer"
+    },
+    {
+      "name": "description",
+      "title": "item description",
+      "type": "string",
+      "missingValues": [ "n/a"]
+    },
+    {
+      "name": "price",
+      "title": "cost price",
+      "type": "number",
+      "missingValues": [ "-1"]
+    }
+  ],
+  "missingValues": [ "tba", "" ]
+}
+```
+
+...would be interpreted as...
+
+item   | description | price
+------ | ----------- | ------
+1      | Apple       | 0.99
+`null` | Banana      | `null`
+3      | `null`      | 1.20
+
+### Specification
+
+A field MAY have a `missingValues` property that MUST be an `array` where each entry is a `string`. If not specified, each field inherits from the values assigned to [`missingValues`](http://frictionlessdata.io/specs/table-schema/#missing-values) at the Tabular Data Resource level.
+
+### Implementations
+
+None known.


### PR DESCRIPTION
#### Description: 
This is a 'rebase' of #608 'Missing value per field pattern'.  I didn't find a straight forward way to pull the original commit da1660d  from `specs/patterns.md`to the new file `patterns/README.md`.  So this change manually takes the change content of da1660d and adds it to the bottom of the current file.   It didn't look like there was any particular order to the sections in `patterns/README.md` so I added da1660d's content to the end of the file.  Let me know if this needs to be moved and I'll make the change.

#### Original information:
Author: Stephen-Gates <Stephen.Gates@me.com>
Date:   Sat Apr 7 20:40:44 2018 +1000
WIP missing value per field pattern
as per https://discuss.okfn.org/t/missing-values-per-field-pattern/6571

#### Notes:
If this change is no longer desired, go ahead and close this pull request.  
If this change is accepted then #608 can probably be closed when this pull-request merges.

#### Testing:

Pushed this branch to my fork and visually verified the new content regarding 'Missing Values..' is visible in `patterns/README.md`.

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.


Thank you,
DC
