### PR TITLE
Fix JSON Schema "organisation -> organization"

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -156,7 +156,7 @@
         "email": {
           "$ref": "#/definitions/email"
         },
-        "organisation": {
+        "organization": {
           "title": "Organization",
           "description": "An organizational affiliation for this contributor.",
           "type": "string"

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -182,7 +182,7 @@ contributor:
       "$ref": "#/definitions/path"
     email:
       "$ref": "#/definitions/email"
-    organisation:
+    organization:
       title: Organization
       description: An organizational affiliation for this contributor.
       type: string


### PR DESCRIPTION
According to the specs - https://specs.frictionlessdata.io/data-package/#contributors - it should be with Z