### PR TITLE
[spelling][xs]: Spell organisation as organization

### DIFF
--- a/fiscal-data-package--budgets/README.md
+++ b/fiscal-data-package--budgets/README.md
@@ -5,7 +5,7 @@ created: 14 March 2014
 updated: 22 April 2018
 descriptor: fiscal-data-package-budgets.json
 under-development: true
-abstract: The Budget Taxonomy is a set of ColumnTypes to be used in the context of a Fiscal Data Package to describe budget data of organisations (governments or otherwise.)  
+abstract: The Budget Taxonomy is a set of ColumnTypes to be used in the context of a Fiscal Data Package to describe budget data of organizations (governments or otherwise.)  
 sidebar: auto
 ---
 
@@ -532,4 +532,3 @@ The display name for the Top Level Geographic feature specified in the data
 The display name of the geographic feature
  - *dataType*: string
  - *labelOf*: `geo:target:code`
-

--- a/fiscal-data-package--spending/README.md
+++ b/fiscal-data-package--spending/README.md
@@ -5,7 +5,7 @@ created: 14 March 2014
 updated: 22 April 2018
 descriptor: fiscal-data-package-spending.json
 under-development: true
-abstract: The Budget Taxonomy is a set of ColumnTypes to be used in the context of a Fiscal Data Package to describe spending data of organisations (governments or otherwise.)  
+abstract: The Budget Taxonomy is a set of ColumnTypes to be used in the context of a Fiscal Data Package to describe spending data of organizations (governments or otherwise.)  
 sidebar: auto
 ---
 
@@ -323,4 +323,3 @@ Unique identifier for the Tender Kind for this transaction
 
 Unique identifier for the Transaction Kind for this transaction
  - *dataType*: string
-

--- a/patterns/README.md
+++ b/patterns/README.md
@@ -494,13 +494,13 @@ _In some cases, schemas are created after a legal text or some draft specificati
     {
       "title": "John Smith",
       "email": "john.smith@etalab.gouv.fr",
-      "organisation": "Etalab",
+      "organization": "Etalab",
       "role": "author"
     },
     {
       "title": "Jane Doe",
       "email": "jane.doe@aol.com",
-      "organisation": "Civil Society Organization X",
+      "organization": "Civil Society Organization X",
       "role": "contributor"
     }
   ],


### PR DESCRIPTION
* Complements the work done in d2cd3aaa454541c883bd9514186148e28c22541c
* Fixes #693

Changes made to `patterns/README.md` in particular were necessary as the examples went against the specs.