### PR TITLE
[redirects][s]: Redirect for `simple-data-format`

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,0 +1,13 @@
+export default ({ router }) => {
+  router.beforeEach((to, from, next) => {
+    const redirectList = {
+      '/simple-data-format': '/tabular-data-package/',
+      '/simple-data-format/': '/tabular-data-package/',
+    };
+    const redirect = redirectList[to.path];
+
+    if (redirect) {
+      next({ path: redirect });
+    } else next();
+  });
+};


### PR DESCRIPTION
* Redirect `/simple-data-format/` to `/tabular-data-package/`
* Fixes #535

There is no longer any occurrence of the route `/simple-data-format` in the repo, but this takes into account the original one that existed. Additionally, the page `/guides/tabular-data-package/` is now found at `/tabular-data-package/`, so the redirect is pointing there: https://specs.frictionlessdata.io/tabular-data-package/