### PR TITLE
[logo][xs]: Update URL to new Frictionless logo

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -14,7 +14,7 @@ module.exports = {
     }
   },
   themeConfig: {
-    logo: "/logo-dot.svg",
+    logo: 'https://frictionlessdata.io/img/frictionless-color-logo.svg',
     repo: 'https://github.com/frictionlessdata/specs',
     editLinks: true,
     sidebar: [ 


### PR DESCRIPTION
* Set absolute path to the main repo so that changes will be kept in sync.
* Use URL https://frictionlessdata.io/img/frictionless-color-logo.svg instead of https://frictionlessdata.io/img/frictionless-color-full-logo.svg because we only need to display the logo without additional text.
* Fixes https://github.com/frictionlessdata/project/issues/481.