### PR TITLE
Table Schema: add optional examples for fields

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -56,6 +56,14 @@
         "{\n  \"description\": \"# My Package description\\nAll about my package.\"\n}\n"
       ]
     },
+    "example": {
+      "title": "Example",
+      "description": "An example value for the field.",
+      "type": "string",
+      "examples": [
+        "{\n  \"example\": \"Put here an example value for your field\"\n}\n"
+      ]
+    },
     "homepage": {
       "title": "Home Page",
       "description": "The home on the web that is related to this data package.",
@@ -534,7 +542,7 @@
       "title": "Skip Initial Space",
       "description": "Specifies the interpretation of whitespace immediately following a delimiter. If false, whitespace immediately after a delimiter should be treated as part of the subsequent field.",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "examples": [
         "{\n  \"skipInitialSpace\": true\n}\n"
       ]
@@ -1249,6 +1257,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `string`.",
           "enum": [
@@ -1320,6 +1331,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `boolean`.",
           "enum": [
@@ -1378,6 +1392,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `integer`.",
@@ -1463,6 +1480,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `number`.",
@@ -1558,6 +1578,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `date`.",
           "enum": [
@@ -1619,6 +1642,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `time`.",
           "enum": [
@@ -1679,6 +1705,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `datetime`.",
           "enum": [
@@ -1738,6 +1767,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `year`.",
@@ -1822,6 +1854,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `yearmonth`.",
           "enum": [
@@ -1885,6 +1920,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `duration`.",
           "enum": [
@@ -1945,6 +1983,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `object`.",
@@ -2014,6 +2055,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `array`.",
           "enum": [
@@ -2081,6 +2125,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `geojson`.",
@@ -2153,6 +2200,9 @@
         "description": {
           "$ref": "#/definitions/description"
         },
+        "example": {
+          "$ref": "#/definitions/example"
+        },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `geopoint`.",
           "enum": [
@@ -2224,6 +2274,9 @@
         },
         "description": {
           "$ref": "#/definitions/description"
+        },
+        "example": {
+          "$ref": "#/definitions/example"
         },
         "type": {
           "description": "The type keyword, which `MUST` be a value of `any`.",

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -74,6 +74,15 @@ description:
     {
       "description": "# My Package description\nAll about my package."
     }
+example:
+  title: Example
+  description: An example value for the field.
+  type: string
+  examples:
+  - |
+    {
+      "example": "Put here an example value for your field"
+    }
 homepage:
   title: Home Page
   description: The home on the web that is related to this data package.
@@ -99,7 +108,7 @@ version:
       }
 path:
   title: Path
-  description: A fully qualified URL, or a POSIX file path..
+  description: A fully qualified URL, or a POSIX file path.
   type: string
   pattern: "^(?=^[^.\/~])(^((?!\\.{2}).)*$).*$"
   examples:

--- a/schemas/dictionary/tableschema.yml
+++ b/schemas/dictionary/tableschema.yml
@@ -244,6 +244,8 @@ tableSchemaFieldString:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `string`.
       enum:
@@ -319,6 +321,8 @@ tableSchemaFieldBoolean:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `boolean`.
       enum:
@@ -364,6 +368,8 @@ tableSchemaFieldInteger:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `integer`.
       enum:
@@ -435,6 +441,8 @@ tableSchemaFieldNumber:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `number`.
       enum:
@@ -503,6 +511,8 @@ tableSchemaFieldDate:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `date`.
       enum:
@@ -566,6 +576,8 @@ tableSchemaFieldTime:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `time`.
       enum:
@@ -621,6 +633,8 @@ tableSchemaFieldDateTime:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `datetime`.
       enum:
@@ -677,6 +691,8 @@ tableSchemaFieldYear:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `year`.
       enum:
@@ -739,6 +755,8 @@ tableSchemaFieldYearMonth:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `yearmonth`.
       enum:
@@ -796,6 +814,8 @@ tableSchemaFieldDuration:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `duration`.
       enum:
@@ -842,6 +862,8 @@ tableSchemaFieldObject:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `object`.
       enum:
@@ -890,6 +912,8 @@ tableSchemaFieldArray:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `array`.
       enum:
@@ -938,6 +962,8 @@ tableSchemaFieldGeoJSON:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `geojson`.
       enum:
@@ -997,6 +1023,8 @@ tableSchemaFieldGeoPoint:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `geopoint`.
       enum:
@@ -1058,6 +1086,8 @@ tableSchemaFieldAny:
       "$ref": "#/definitions/title"
     description:
       "$ref": "#/definitions/description"
+    example:
+      "$ref": "#/definitions/example"
     type:
       description: The type keyword, which `MUST` be a value of `any`.
       enum:

--- a/table-schema/README.md
+++ b/table-schema/README.md
@@ -3,7 +3,7 @@ title: Table Schema
 version: 1.0
 author: Paul Walsh, Rufus Pollock
 created: 12 November 2012
-updated: 6 October 2020
+updated: 5 October 2021
 descriptor: table-schema.json
 mediatype: application/vnd.tableschema+json
 abstract: A simple format to declare a schema for tabular data. The schema is designed to be expressible in JSON.
@@ -85,6 +85,7 @@ The following is an illustration of this structure:
       "title": "A nicer human readable label or title for the field",
       "type": "A string specifying the type",
       "format": "A string specifying a format",
+      "example": "An example value for the field",
       "description": "A description for the field"
       ...
     },
@@ -114,6 +115,7 @@ Here is an illustration:
   "title": "A nicer human readable label or title for the field",
   "type": "A string specifying the type",
   "format": "A string specifying a format",
+  "example": "An example value for the field",
   "description": "A description for the field",
   "constraints": {
       // a constraints-descriptor
@@ -134,6 +136,11 @@ A human readable label or title for the field
 ### `description`
 
 A description for this field e.g. "The recipient of the funds"
+
+### `example`
+
+An example value for the field
+
 
 ### Types and Formats
 


### PR DESCRIPTION
Add a new optional field, `example` for Table Schema fields. `example` can be used to provide an example value for each. This helps producers/reusers know what values are allowed. This can also be use to build example files with sensible values.

@roll, I skipped the pattern phase and I'm proposing directly a spec update as @johanricher suggested in https://github.com/frictionlessdata/specs/issues/740#issuecomment-925060185