### PR TITLE
Tweak DataResource docs

### DIFF
--- a/data-resource/README.md
+++ b/data-resource/README.md
@@ -34,7 +34,7 @@ With data accessible via the local filesystem.
 
 ```javascript
 {
-  "name": "resource-name.csv",
+  "name": "resource-name",
   "path": "resource-path.csv"
 }
 ```
@@ -43,7 +43,7 @@ With data accessible via http.
 
 ```javascript
 {
-  "name": "resource-name.csv",
+  "name": "resource-name",
   "path": "http://example.com/resource-path.csv"
 }
 ```
@@ -52,7 +52,7 @@ A minimal Data Resource pointing to some inline data looks as follows.
 
 ```javascript
 {
-  "name": "resource-name.csv",
+  "name": "resource-name",
   "data": {
     "resource-name-data": [
       {"a": 1, "b": 2}


### PR DESCRIPTION
Under Metadata Properties, it is recommended for `name` to drop the extension. Updating minimal examples to reflect that recommendation.