### PR TITLE
Enforce that `license` has `name` or `path`

### DIFF
--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -232,6 +232,11 @@ license:
   title: License
   description: A license for this descriptor.
   type: object
+  oneOf:
+    - required:
+      - name
+    - required:
+      - path
   properties:
     name:
       title: Open Definition license identifier


### PR DESCRIPTION
According to https://specs.frictionlessdata.io/data-package/#licenses

> licenses MUST be an array. Each item in the array is a License. Each MUST be an object. **The object MUST contain a name property and/or a path property**. It MAY contain a title property.

This was not enforced by the specs (i.e. a license could be added that had neither of those properties). This PR adds that condition (I hope).