### PR TITLE
Add license scope

### DIFF
--- a/data-package/README.md
+++ b/data-package/README.md
@@ -191,6 +191,7 @@ Here is an example:
 * `name`: The `name` `MUST` be an [Open Definition license ID][od-licenses]
 * `path`: A [url-or-path][] string, that is a fully qualified HTTP address, or a relative POSIX path (see [the url-or-path definition in Data Resource for details][url-or-path]).
 * `title`: A human-readable title.
+* `scope`: A human-readable clarification that what element(s) the license applies, especially in the case of multiple licenses.
 
 [od-licenses]: http://licenses.opendefinition.org/
 [od-approved]: http://opendefinition.org/licenses/

--- a/data-package/README.md
+++ b/data-package/README.md
@@ -176,7 +176,7 @@ The license(s) under which the package is provided.
 
 **This property is not legally binding and does not guarantee the package is licensed under the terms defined in this property.**
 
-`licenses` `MUST` be an array. Each item in the array is a License. Each `MUST` be an `object`. The object `MUST` contain a `name` property and/or a `path` property. It `MAY` contain a `title` property.
+`licenses` `MUST` be an array. Each item in the array is a License. Each `MUST` be an `object`. The object `MUST` contain a `name` property and/or a `path` property. It `MAY` contain a `title` and `scope` property.
 
 Here is an example:
 

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -247,6 +247,10 @@ license:
       "$ref": "#/definitions/path"
     title:
       "$ref": "#/definitions/title"
+    scope:
+      title: License scope
+      description: Clarification that what element(s) the license applies, especially in the case of multiple licenses.
+      type: string
   context: Use of this property does not imply that the person was the original
     creator of, or a contributor to, the data in the descriptor, but refers to the
     composition of the descriptor itself.


### PR DESCRIPTION
The current specs specify [licenses](https://specs.frictionlessdata.io/data-package/#licenses) as an array, allowing 0 or more licenses. In [Camtrap DP](https://github.com/tdwg/camtrap-dp/pull/193), we like to use that ability to indicate the license of a Data Package (e.g. CC0) _and_ the license of images referred to by a Data Resource (e.g. CC BY). The issue with multiple (maybe conflicting) licenses is that users don't know to what each one applies. We therefore suggest to add an optional `scope` property:

```json
"licenses": [{
  "name": "CC0-1.0",
  "scope": "data" <- License applies to the data in the package
},
{
  "name": "CC-BY-4.0",
  "scope": "media" <- License applies to the referenced media files
}]
```

This proposal was discussed in context of Camtrap DP, with input from members of the Frictionless Community at https://github.com/tdwg/camtrap-dp/issues/189#issuecomment-1015681670

Characteristics:

- Field is optional, even for multiple licenses.
- As with the `licenses` field as a whole "This property is not legally binding and does not guarantee the package is licensed under the terms defined in this property." It is only there to more clearly communicate intent to the user.
- Values would be free text, but communities could add more stringent requirements (like an `enum`)
- It could apply to Data Package `licenses` as well as Data Resource `licenses`