### PR TITLE
Fix licenses JSON Schema

### DIFF
--- a/schemas/dictionary.json
+++ b/schemas/dictionary.json
@@ -206,7 +206,7 @@
       "title": "License",
       "description": "A license for this descriptor.",
       "type": "object",
-      "oneOf": [
+      "anyOf": [
         {
           "required": [
             "name"

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -241,7 +241,7 @@ license:
   title: License
   description: A license for this descriptor.
   type: object
-  oneOf:
+  anyOf:
     - required:
       - name
     - required:


### PR DESCRIPTION
Related issues: https://github.com/frictionlessdata/tableschema-ui/issues/11

The [documentation](https://specs.frictionlessdata.io/data-package/) says

> The object MUST contain a name property and/or a path property.

The JSON Schema has a bug because a JSON Schema validator (e.g. https://www.jsonschemavalidator.net/) will tell you

>  Found 1 error(s)
> Message: JSON is valid against more than one schema from 'oneOf'. Valid schema indexes: 0, 1.
> Schema path: #/properties/licenses/items/oneOf

for

```
  "licenses": [
    {
      "name": "CC0-1.0",
      "title": "CC0 1.0",
      "path": "https://creativecommons.org/publicdomain/zero/1.0/"
    }
  ]
```