### PR TITLE
Make tabular-data-package example valid

### DIFF
--- a/tabular-data-package/README.md
+++ b/tabular-data-package/README.md
@@ -96,8 +96,9 @@ B,3,4.5
   // here we list the data files in this dataset
   "resources": [
     {
-      "path": "data.csv",
       "profile": "tabular-data-resource",
+      "name": "data",
+      "path": "data.csv",
       "schema": {
         "fields": [
           {


### PR DESCRIPTION
The example on https://specs.frictionlessdata.io/tabular-data-package/#example is currently not valid, because the resource is missing a `name` property.

I added one called `data` (after `data.csv`), and order the terms as:

- profile
- name
- path

Similar to how those terms are listed in https://specs.frictionlessdata.io/tabular-data-resource/#examples