### PR TITLE
Change markdown link to html link, so it renders on website

### DIFF
--- a/table-schema/README.md
+++ b/table-schema/README.md
@@ -503,7 +503,7 @@ properties.
       <code>string</code>
     </td>
     <td>
-      A regular expression that can be used to test field values. If the regular expression matches then the value is valid. The values of this field <code>MUST</code> conform to the standard [XML Schema regular expression syntax](http://www.w3.org/TR/xmlschema-2/#regexs).
+      A regular expression that can be used to test field values. If the regular expression matches then the value is valid. The values of this field <code>MUST</code> conform to the standard <a href="http://www.w3.org/TR/xmlschema-2/#regexs">XML Schema regular expression syntax</a>.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
The table in [constraints](https://specs.frictionlessdata.io/table-schema/#constraints) contains a link to the regex spec, but is rendered as plain markdown, because the text is wrapped in a html table cell `<td>`:

```
[XML Schema regular expression syntax](http://www.w3.org/TR/xmlschema-2/#regexs)
```

Depending on the Markdown parser used to render the pages, there are solutions around this (e.g. write the table as a markdown table, or add the `markdown=1` property). But since the other formatting in the table is done as html (e.g. `<code> MUST</code>`), I simply opted here to convert the markdown link to a `<a>` link.