### PR TITLE
fix(schemas): Require `type` on tableSchemaFieldNumber

### DIFF
--- a/schemas/dictionary/tableschema.yml
+++ b/schemas/dictionary/tableschema.yml
@@ -436,6 +436,7 @@ tableSchemaFieldNumber:
     If both exponent and percentages are present the percentage `MUST` follow the exponent e.g. '53E10%' (equals 5.3).
   required:
   - name
+  - type
   properties:
     name:
       "$ref": "#/definitions/tableSchemaFieldName"


### PR DESCRIPTION
`"type": "number"` is functionally required on these objects, since an object lacking that property is supposed to be understood as a tableSchemaFieldString instead, per:

https://github.com/frictionlessdata/specs/blob/9e4d58012d80190574d0a1d7038abe4924f9e714/table-schema/README.md?plain=1#L147-L148