### PR TITLE
Allow a role or *array of roles* for contributor role

### DIFF
--- a/data-package/README.md
+++ b/data-package/README.md
@@ -268,13 +268,13 @@ The people or organizations who contributed to this Data Package. It `MUST` be a
 * `title`: name/title of the contributor (name for person, name/title of organization)
 * `path`: a fully qualified http URL pointing to a relevant location online for the contributor
 * `email`: An email address
-* `role`: a string describing the role of the contributor. It's `RECOMMENDED` to be one of: `author`, `publisher`, `maintainer`, `wrangler`, and `contributor`. Defaults to `contributor`.
+* `role`: a string or array of strings describing the role(s) of the contributor. It's `RECOMMENDED` to be one of: `author`, `publisher`, `maintainer`, `wrangler`, and `contributor`. Defaults to `contributor`.
   * Note on semantics: use of the "author" property does not imply that that person was the original creator of the data in the data package - merely that they created and/or maintain the data package. It is common for data packages to "package" up data from elsewhere. The original origin of the data can be indicated with the `sources` property - see above.
 * `organization`: a string describing the organization this contributor is affiliated to.
 
 ##### `keywords`
 
-An Array of string keywords to assist users searching for the package in catalogs.
+An array of string keywords to assist users searching for the package in catalogs.
 
 ##### `image`
 

--- a/schemas/dictionary/common.yml
+++ b/schemas/dictionary/common.yml
@@ -198,7 +198,10 @@ contributor:
       description: An organizational affiliation for this contributor.
       type: string
     role:
-      type: string
+      oneOf: [
+        { "$ref": "#/definitions/role" },
+        { "$ref": "#/definitions/roleArray" }
+      ]
       default: contributor
   required:
   - title
@@ -273,6 +276,13 @@ licenses:
           }
         ]
       }
+role:
+  type: string
+roleArray:
+  type: array
+  minItems: 1
+  items:
+    "$ref": "#/definitions/role"
 source:
   title: Source
   description: A source file.


### PR DESCRIPTION
This PR extends contributor `role` from a string to a **string OR array of strings** and related to #804. Note that `enum` restrictions on what roles are allowed were already removed as part of #809.

## Why

Allowing multiple roles per contributor removes the current drawback where contributors have to be duplicated just because they performed multiple roles for a Data Package. Duplication is annoying for data publishers and software implementations (especially disambiguating contributors that look the same). Allowing multiple roles per contributor is a use case we have in [Camtrap DP](https://github.com/tdwg/camtrap-dp/issues/345). **Profiles (like Camtrap DP) currently can't extend to allow multiple roles** since Data Package requires `role` to be of type `string`. 

## Software implementations

This change has an effect on software implementations, but only if they make use of contributor `role` _and_ only for (new) Data Packages that provide contributor `role` as an array. Existing Data Packages (with `role` as string) are still valid.

- Frictionless Framework should be updated to pass validation for `role` as array
- Other software implementations that make use of `role` might have to pick the first element of an array if they only support one role per contributor.

## Changes in this PR

To the best of my ability, I made the changes where I think they should be implemented in this repo, but have likely made mistakes.

1. While it is technically possible to just change `role` from a string to an array (since a single role can be expressed as a array of length 1), I think it is better to allow both, since it is easier for data providers _and_ backwards compatible.
2. I took from inspiration from `resourcePath` which also allows strings and array of strings: https://github.com/frictionlessdata/specs/blob/6b4009428c141e7308349e113c40f633d9da2bea/schemas/dictionary/resource.yml#L159-L162

    ... and created two extra definitions for role: `role` and `roleArray` (in `common.yml`, alphabetically after `licenses` and before `source`).
4. The `items` for `roleArray` expect a `role`, so that any added requirements for `role` are immediately adopted for `roleArray` items as well.
5. Minimum one value is expected for `roleArray`
6. I updated the description of role in `data-package/README.md` 