### PR TITLE
chore: Add typescript implementation and validator mentions

### DIFF
--- a/components/SocialIcons.astro
+++ b/components/SocialIcons.astro
@@ -11,7 +11,7 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 <Default {...Astro.props}><slot /></Default>
 
 <div class="validator">
-  <a href="https://validator.datapackage.org/"><strong>Validator</strong></a>
+  <a href="https://datapackage-validator.datist.io"><strong>Validator</strong></a>
 </div>
 
 <!-- Add styles to mimic the default links appearance. -->

--- a/components/SocialIcons.astro
+++ b/components/SocialIcons.astro
@@ -10,6 +10,8 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 
 <Default {...Astro.props}><slot /></Default>
 
+<div class="validator"><a href="https://validator.datapackage.org/"><strong>Validator</strong></a></div>
+
 <!-- Add styles to mimic the default links appearance. -->
 <style>
   a {
@@ -20,5 +22,14 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 
   a:hover {
     opacity: 0.66;
+  }
+
+  div.validator {
+    border-left: 1px solid var(--sl-color-gray-5);
+    padding-left: 1rem;
+  }
+
+  div.validator a {
+    text-decoration: none;
   }
 </style>

--- a/components/SocialIcons.astro
+++ b/components/SocialIcons.astro
@@ -10,7 +10,9 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 
 <Default {...Astro.props}><slot /></Default>
 
-<div class="validator"><a href="https://validator.datapackage.org/"><strong>Validator</strong></a></div>
+<div class="validator">
+  <a href="https://validator.datapackage.org/"><strong>Validator</strong></a>
+</div>
 
 <!-- Add styles to mimic the default links appearance. -->
 <style>

--- a/content/docs/overview/software.mdx
+++ b/content/docs/overview/software.mdx
@@ -54,6 +54,16 @@ Data Package is backed by a comprehensive list of software products supporting t
   />
 </CardGrid>
 
+## TypeScript
+
+<CardGrid>
+  <LinkCard
+    title="frictionless-ts"
+    description="Fast TypeScript data management framework built on top of the Data Package standard and Polars DataFrames"
+    href="https://frictionlessdata.github.io/frictionless-ts"
+  />
+</CardGrid>
+
 ## JavaScript
 
 <CardGrid>

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "generate": "vite-node scripts/generate.ts",
     "lint": "eslint . && prettier --check .",
     "prepare": "husky",
-    "preview": "npm run build && astro preview --open --port 8080",
-    "start": "astro dev",
+    "preview": "npm run build && astro preview --open --port 5000",
+    "start": "astro dev --port 5000",
     "update": "ncu -u",
     "test": "npm run lint",
     "type": "tsc"


### PR DESCRIPTION
- Added https://github.com/frictionlessdata/frictionless-ts to the software section
- Added a validator link - https://github.com/frictionlessdata/datapackage-validator

To finish the validator setup the `validator.datapackage.org` needs to point to Github Pages IPs - https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site

Currently, the validator is available at https://datapackage-validator.datist.io