### PR TITLE
chore: Finish validator setup

### DIFF
--- a/components/SocialIcons.astro
+++ b/components/SocialIcons.astro
@@ -11,7 +11,7 @@ import Default from "@astrojs/starlight/components/SocialIcons.astro"
 <Default {...Astro.props}><slot /></Default>
 
 <div class="validator">
-  <a href="https://datapackage-validator.datist.io"><strong>Validator</strong></a>
+  <a href="https://validator.datapackage.org"><strong>Validator</strong></a>
 </div>
 
 <!-- Add styles to mimic the default links appearance. -->


### PR DESCRIPTION
- Updated the validator link - https://github.com/frictionlessdata/datapackage-validator

To finish the validator setup the `validator.datapackage.org` needs to point to Github Pages IPs - https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site

Currently, the validator is available at https://datapackage-validator.datist.io