### PR TITLE
fix: require `type` for "string" fields; don't for "any" fields

### DIFF
--- a/profiles/dictionary/schema.yaml
+++ b/profiles/dictionary/schema.yaml
@@ -269,6 +269,7 @@ tableSchemaFieldString:
   description: The field contains strings, that is, sequences of characters.
   required:
     - name
+    - type
   properties:
     name:
       "$ref": "#/definitions/tableSchemaFieldName"
@@ -1256,7 +1257,6 @@ tableSchemaFieldAny:
     the type/format/constraint requirements of the specification.
   required:
     - name
-    - type
   properties:
     name:
       "$ref": "#/definitions/tableSchemaFieldName"


### PR DESCRIPTION
- fixes #1147 

---

This adds `type` as required for string fields (aligned with the other typed fields), and removes `type` as required for any fields. This aligns with the [textual description](https://datapackage.org/standard/table-schema/#type-and-format) of field types in the spec: 
> the absence of a type property indicates that the field is of the type “any”
